### PR TITLE
correctly placing species as a reactant in a first order loss reaction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 # must be on the same line so that pyproject.toml can correctly identify the version
-project(mechanism_configuration VERSION 0.1.0 LANGUAGES CXX)
+project(mechanism_configuration VERSION 0.1.1 LANGUAGES CXX)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING

--- a/include/mechanism_configuration/version.hpp
+++ b/include/mechanism_configuration/version.hpp
@@ -9,7 +9,7 @@ extern "C" {
 
   const char* getVersionString()
   {
-    return "0.1.0";
+    return "0.1.1";
   }
   unsigned getVersionMajor()
   {
@@ -21,7 +21,7 @@ extern "C" {
   }
   unsigned getVersionPatch()
   {
-    return 0+0;
+    return 1+0;
   }
   unsigned getVersionTweak()
   {

--- a/src/v0/first_order_loss_parser.cpp
+++ b/src/v0/first_order_loss_parser.cpp
@@ -23,7 +23,8 @@ namespace mechanism_configuration
         YAML::Node products_object{};
         std::vector<types::ReactionComponent> reactants;
         std::vector<types::ReactionComponent> products;
-        products.push_back({ .species_name = species, .coefficient = 1.0 });
+
+        reactants.push_back({ .species_name = species, .coefficient = 1.0 });
         double scaling_factor = object[validation::SCALING_FACTOR] ? object[validation::SCALING_FACTOR].as<double>() : 1.0;
 
         std::string name = "LOSS." + object[validation::MUSICA_NAME].as<std::string>();

--- a/test/unit/v0/test_first_order_loss_config.cpp
+++ b/test/unit/v0/test_first_order_loss_config.cpp
@@ -50,18 +50,18 @@ TEST(FirstOrderLossConfig, ParseConfig)
 
     // first reaction
     {
-      EXPECT_EQ(process_vector[0].reactants.size(), 0);
-      EXPECT_EQ(process_vector[0].products.size(), 1);
-      EXPECT_EQ(process_vector[0].products[0].species_name, "foo");
+      EXPECT_EQ(process_vector[0].reactants.size(), 1);
+      EXPECT_EQ(process_vector[0].products.size(), 0);
+      EXPECT_EQ(process_vector[0].reactants[0].species_name, "foo");
       EXPECT_EQ(process_vector[0].name, "LOSS.foo");
       EXPECT_EQ(process_vector[0].scaling_factor, 1.0);
     }
 
     // second reaction
     {
-      EXPECT_EQ(process_vector[1].reactants.size(), 0);
-      EXPECT_EQ(process_vector[1].products.size(), 1);
-      EXPECT_EQ(process_vector[1].products[0].species_name, "bar");
+      EXPECT_EQ(process_vector[1].reactants.size(), 1);
+      EXPECT_EQ(process_vector[1].products.size(), 0);
+      EXPECT_EQ(process_vector[1].reactants[0].species_name, "bar");
       EXPECT_EQ(process_vector[1].name, "LOSS.bar");
       EXPECT_EQ(process_vector[1].scaling_factor, 2.5);
     }


### PR DESCRIPTION
Corrects the first order loss for version zero. The species was being placed as a product rather than a reactant, which made the first order loss function like an emission reaction instead of a loss.

I'm also bumping the patch of the version so that we can make a new release here and in musica