### PR TITLE
Bump yaml cpp version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ RUN dnf -y update \
         gcc-c++ \
         gdb \
         git \
+        lcov \
         make \
+        python-devel \
     && dnf clean all
 
 COPY . /mechanism_configuration/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN dnf -y update \
         gcc-c++ \
         gdb \
         git \
-        lcov \
         make \
         python-devel \
     && dnf clean all

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -29,9 +29,12 @@ endif()
 ################################################################################
 # yaml-cpp
 
+set_git_default(YAML_CPP_GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git)
+set_git_default(YAML_CPP_GIT_TAG 28f93bdec6387d42332220afa9558060c8016795)
+
 FetchContent_Declare(yaml-cpp
-    GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-    GIT_TAG 0.8.0
+    GIT_REPOSITORY ${YAML_CPP_GIT_REPOSITORY}
+    GIT_TAG        ${YAML_CPP_GIT_TAG}
 )
 
 set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
A [musica PR](https://github.com/NCAR/musica/pull/295) started failing its dockerfile tests. This is because fedora seems to have updated to gcc 15 as the default and [yaml-cpp 0.8.0 is not compatible with gcc 15](https://github.com/jbeder/yaml-cpp/pull/1310). This sets a variable we can use to control which version is built and points to the most commit of yaml-cpp.