### PR TITLE
Support multiple phases for modal model

### DIFF
--- a/examples/v1/full_configuration.json
+++ b/examples/v1/full_configuration.json
@@ -115,13 +115,13 @@
           "name": "aitken",
           "geometric mean diameter [m]": 2.6e-8,
           "geometric standard deviation": 1.6,
-          "phase": "aqueous"
+          "phases": "aqueous"
         },
         {
           "name": "accumulation",
           "geometric mean diameter [m]": 1.1e-7,
           "geometric standard deviation": 1.8,
-          "phase": "aqueous"
+          "phases": ["aqueous", "organic"]
         }
       ]
     }

--- a/examples/v1/full_configuration.yaml
+++ b/examples/v1/full_configuration.yaml
@@ -65,6 +65,7 @@ phases:
   species:
   - B
   - C
+
 models:
 - name: gas
   type: GAS_PHASE
@@ -75,12 +76,16 @@ models:
   - name: aitken
     geometric mean diameter [m]: 2.6e-8
     geometric standard deviation: 1.6
-    phase: aqueous
+    phases:
+     - aqueous
 
   - name: accumulation
     geometric mean diameter [m]: 1.1e-7
     geometric standard deviation: 1.8
-    phase: aqueous
+    phases:
+      - aqueous
+      - cloud
+
 reactions:
 - type: HL_PHASE_TRANSFER
   gas:

--- a/include/mechanism_configuration/v1/model_types.hpp
+++ b/include/mechanism_configuration/v1/model_types.hpp
@@ -31,7 +31,7 @@ namespace mechanism_configuration
         std::string name;
         double geometric_mean_diameter;
         double geometric_standard_deviation;
-        std::string phase;
+        std::vector<std::string> phases;
         /// @brief Unknown properties, prefixed with two underscores (__)
         std::unordered_map<std::string, std::string> unknown_properties;
       };

--- a/include/mechanism_configuration/v1/validation.hpp
+++ b/include/mechanism_configuration/v1/validation.hpp
@@ -187,7 +187,7 @@ namespace mechanism_configuration
       static constexpr const char* geometric_standard_deviation = "geometric standard deviation";
       // also
       // name
-      // phase
+      // phases
 
     }  // namespace validation
   }  // namespace v1

--- a/test/unit/v1/models/test_parse_modal.cpp
+++ b/test/unit/v1/models/test_parse_modal.cpp
@@ -8,10 +8,12 @@ TEST(ParserBase, CanParseValidModalModel)
 {
   v1::Parser parser;
   std::vector<std::string> extensions = { ".json", ".yaml" };
+
   for (auto& extension : extensions)
   {
     auto parsed = parser.Parse(std::string("v1_unit_configs/models/modal/valid") + extension);
     EXPECT_TRUE(parsed);
+
     v1::types::Mechanism mechanism = *parsed;
 
     EXPECT_EQ(mechanism.models.modal_model.type, "MODAL");
@@ -20,14 +22,17 @@ TEST(ParserBase, CanParseValidModalModel)
     EXPECT_EQ(mechanism.models.modal_model.modes[0].name, "aitken");
     EXPECT_EQ(mechanism.models.modal_model.modes[0].geometric_mean_diameter, 2.6e-8);
     EXPECT_EQ(mechanism.models.modal_model.modes[0].geometric_standard_deviation, 1.6);
-    EXPECT_EQ(mechanism.models.modal_model.modes[0].phase, "aqueous");
+    EXPECT_EQ(mechanism.models.modal_model.modes[0].phases.size(), 1);
+    EXPECT_EQ(mechanism.models.modal_model.modes[0].phases[0], "aqueous");
     EXPECT_EQ(mechanism.models.modal_model.modes[0].unknown_properties.size(), 1);
     EXPECT_EQ(mechanism.models.modal_model.modes[0].unknown_properties["__comment"], "Aitken mode");
 
     EXPECT_EQ(mechanism.models.modal_model.modes[1].name, "accumulation");
     EXPECT_EQ(mechanism.models.modal_model.modes[1].geometric_mean_diameter, 1.1e-7);
     EXPECT_EQ(mechanism.models.modal_model.modes[1].geometric_standard_deviation, 1.8);
-    EXPECT_EQ(mechanism.models.modal_model.modes[1].phase, "aqueous");
+    EXPECT_EQ(mechanism.models.modal_model.modes[1].phases.size(), 2);
+    EXPECT_EQ(mechanism.models.modal_model.modes[1].phases[0], "aqueous");
+    EXPECT_EQ(mechanism.models.modal_model.modes[1].phases[1], "organic");
     EXPECT_EQ(mechanism.models.modal_model.modes[1].unknown_properties.size(), 0);
   }
 }

--- a/test/unit/v1/v1_unit_configs/models/modal/missing_modal_variable.json
+++ b/test/unit/v1/v1_unit_configs/models/modal/missing_modal_variable.json
@@ -79,13 +79,13 @@
         {
           "name": "aitken",
           "geometric mean diameter [m]": 2.6e-8,
-          "phase": "aqueous",
+          "phases": ["aqueous"],
           "__comment": "Aitken mode"
         },
         {
           "name": "accumulation",
           "geometric mean diameter [m]": 1.1e-7,
-          "phase": "aqueous"
+          "phases": ["aqueous"]
         }
       ]
     }

--- a/test/unit/v1/v1_unit_configs/models/modal/missing_modal_variable.yaml
+++ b/test/unit/v1/v1_unit_configs/models/modal/missing_modal_variable.yaml
@@ -64,12 +64,14 @@ models:
     modes:
       - name: aitken
         geometric mean diameter [m]: 2.6e-8
-        phase: aqueous
+        phases: 
+          - aqueous
         __comment: Aitken mode
 
       - name: accumulation
         geometric mean diameter [m]: 1.1e-7
-        phase: aqueous
+        phases: 
+          - aqueous
 
 reactions:
   - type: HL_PHASE_TRANSFER

--- a/test/unit/v1/v1_unit_configs/models/modal/mode_phase_not_found_in_phases.json
+++ b/test/unit/v1/v1_unit_configs/models/modal/mode_phase_not_found_in_phases.json
@@ -44,14 +44,14 @@
           "name": "aitken",
           "geometric mean diameter [m]": 2.6e-8,
           "geometric standard deviation": 1.6,
-          "phase": "aqueous",
+          "phases": ["aqueous"],
           "__comment": "Aitken mode"
         },
         {
           "name": "accumulation",
           "geometric mean diameter [m]": 1.1e-7,
           "geometric standard deviation": 1.6,
-          "phase": "organic"
+          "phases": ["organic"]
         }
       ]
     }

--- a/test/unit/v1/v1_unit_configs/models/modal/mode_phase_not_found_in_phases.yaml
+++ b/test/unit/v1/v1_unit_configs/models/modal/mode_phase_not_found_in_phases.yaml
@@ -27,13 +27,15 @@ models:
       - name: aitken
         geometric mean diameter [m]: 2.6e-8
         geometric standard deviation: 1.6
-        phase: aqueous
+        phases: 
+          - aqueous
         __comment: Aitken mode
 
       - name: accumulation
         geometric mean diameter [m]: 1.1e-7
         geometric standard deviation: 1.6
-        phase: organic
+        phases: 
+          - organic
 
 reactions:
   - type: HL_PHASE_TRANSFER

--- a/test/unit/v1/v1_unit_configs/models/modal/valid.json
+++ b/test/unit/v1/v1_unit_configs/models/modal/valid.json
@@ -69,6 +69,12 @@
         "O3",
         "H2O2"
       ]
+    },
+    {
+      "name": "organic",
+      "species": [
+        "organic carbon"
+      ]
     }
   ],
   "models": [
@@ -85,14 +91,14 @@
           "name": "aitken",
           "geometric mean diameter [m]": 2.6e-8,
           "geometric standard deviation": 1.6,
-          "phase": "aqueous",
+          "phases": ["aqueous"],
           "__comment": "Aitken mode"
         },
         {
           "name": "accumulation",
           "geometric mean diameter [m]": 1.1e-7,
           "geometric standard deviation": 1.8,
-          "phase": "aqueous"
+          "phases": ["aqueous", "organic"]
         }
       ]
     }

--- a/test/unit/v1/v1_unit_configs/models/modal/valid.yaml
+++ b/test/unit/v1/v1_unit_configs/models/modal/valid.yaml
@@ -58,6 +58,10 @@ phases:
       - O3
       - H2O2
 
+  - name: organic
+    species: 
+      - organic carbon
+
 models:
   - name: gas
     type: GAS_PHASE
@@ -69,13 +73,16 @@ models:
       - name: aitken
         geometric mean diameter [m]: 2.6e-8
         geometric standard deviation: 1.6
-        phase: aqueous
+        phases: 
+          - aqueous
         __comment: Aitken mode
 
       - name: accumulation
         geometric mean diameter [m]: 1.1e-7
         geometric standard deviation: 1.8
-        phase: aqueous
+        phases: 
+          - aqueous
+          - organic
 
 reactions:
   - type: HL_PHASE_TRANSFER


### PR DESCRIPTION
This PR

- Supports the multiple phases in a single mode for modal aerosol model.
- Closes #115 

Current:
```JSON
{
  "name": "accumulation",
  "geometric mean diameter [m]": 1.1e-7,
  "geometric standard deviation": 1.8,
  "phase": "aqueous"
}
```

Updated:
```JSON
{
  "name": "accumulation",
  "geometric mean diameter [m]": 1.1e-7,
  "geometric standard deviation": 1.8,
  "phase": ["aqueous", "organic"]
}
```