### PR TITLE
Adjust column limit in clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,7 @@ BreakBeforeBraces: Allman
 BinPackArguments: 'false'
 BinPackParameters: 'false'
 Cpp11BracedListStyle: 'false'
-ColumnLimit: 150
+ColumnLimit: 125
 IndentWidth: 2
 IndentPPDirectives: AfterHash
 NamespaceIndentation: All


### PR DESCRIPTION
For easier editing, this PR adjusts the column limit from 150 to 125, which is the same limit used in musica and micm