### PR TITLE
exploring ways to support backward compatability

### DIFF
--- a/include/mechanism_configuration/development/compatability.hpp
+++ b/include/mechanism_configuration/development/compatability.hpp
@@ -1,0 +1,25 @@
+// Copyright (C) 2023–2025 University Corporation for Atmospheric Research
+//                         University of Illinois at Urbana-Champaign
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <mechanism_configuration/development/model_types.hpp>
+#include <mechanism_configuration/development/reaction_types.hpp>
+#include <mechanism_configuration/development/types.hpp>
+#include <mechanism_configuration/mechanism.hpp>
+
+#include <yaml-cpp/yaml.h>
+
+#include <string>
+#include <vector>
+
+namespace mechanism_configuration
+{
+  namespace development
+  {
+    // Apply backward compatibility transformations to the YAML node
+    void BackwardCompatibleSpeciesName(YAML::Node& node);
+
+  }  // namespace development
+}  // namespace mechanism_configuration

--- a/include/mechanism_configuration/development/validation.hpp
+++ b/include/mechanism_configuration/development/validation.hpp
@@ -14,6 +14,9 @@ namespace mechanism_configuration
       static constexpr const char* version = "version";
       static constexpr const char* name = "name";
 
+      //deprecated in favor of name, but still accepted
+      static constexpr const char* species_name = "species name";
+
       // Configuration
       static constexpr const char* species = "species";
       static constexpr const char* phases = "phases";

--- a/include/mechanism_configuration/parse_status.hpp
+++ b/include/mechanism_configuration/parse_status.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <ostream>
 #include <string>
 
 namespace mechanism_configuration
@@ -38,5 +39,11 @@ namespace mechanism_configuration
     EmptyObject,
   };
 
-  std::string configParseStatusToString(const ConfigParseStatus &status);
+  std::string configParseStatusToString(const ConfigParseStatus& status);
+
+  // For Google Test printing
+  inline void PrintTo(const ConfigParseStatus& status, std::ostream* os)
+  {
+    *os << configParseStatusToString(status);
+  }
 }  // namespace mechanism_configuration

--- a/src/development/CMakeLists.txt
+++ b/src/development/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(mechanism_configuration
   PRIVATE
+    compatability.cpp
     mechanism.cpp
     type_parsers.cpp
     type_validators.cpp

--- a/src/development/compatability.cpp
+++ b/src/development/compatability.cpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2023–2025 University Corporation for Atmospheric Research
+//                         University of Illinois at Urbana-Champaign
+// SPDX-License-Identifier: Apache-2.0
+
+#include <mechanism_configuration/development/compatability.hpp>
+
+namespace mechanism_configuration
+{
+  namespace development
+  {
+    void BackwardCompatibleSpeciesName(YAML::Node& node)
+    {
+      if (node.IsMap())
+      {
+        // If this node has "species name" but not "name", rename it
+        if (node["species name"] && !node["name"])
+        {
+          node["name"] = node["species name"];
+          node.remove("species name");
+        }
+      }
+      else if (node.IsSequence())
+      {
+        for (auto item : node)
+        {
+          BackwardCompatibleSpeciesName(item);
+        }
+      }
+    }
+  }  // namespace development
+}  // namespace mechanism_configuration

--- a/src/development/type_parsers.cpp
+++ b/src/development/type_parsers.cpp
@@ -7,6 +7,7 @@
 #include <mechanism_configuration/development/type_parsers.hpp>
 #include <mechanism_configuration/development/utils.hpp>
 #include <mechanism_configuration/development/validation.hpp>
+#include <mechanism_configuration/development/compatability.hpp>
 #include <mechanism_configuration/error_location.hpp>
 
 namespace mechanism_configuration
@@ -88,7 +89,9 @@ namespace mechanism_configuration
     std::vector<types::ReactionComponent> ParseReactionComponents(const YAML::Node& object, const std::string& key)
     {
       std::vector<types::ReactionComponent> component_list;
-      for (const auto& elem : AsSequence(object[key]))
+      YAML::Node copy = object[key];
+      BackwardCompatibleSpeciesName(copy);
+      for (const auto& elem : AsSequence(copy))
       {
         types::ReactionComponent component;
         component.name = elem[validation::name].as<std::string>();

--- a/src/development/type_validators.cpp
+++ b/src/development/type_validators.cpp
@@ -7,6 +7,7 @@
 #include <mechanism_configuration/development/type_validators.hpp>
 #include <mechanism_configuration/development/utils.hpp>
 #include <mechanism_configuration/development/validation.hpp>
+#include <mechanism_configuration/development/compatability.hpp>
 #include <mechanism_configuration/error_location.hpp>
 #include <mechanism_configuration/errors.hpp>
 #include <mechanism_configuration/validate_schema.hpp>
@@ -196,12 +197,13 @@ namespace mechanism_configuration
     Errors ValidateReactantsOrProducts(const YAML::Node& list)
     {
       const std::vector<std::string> required_keys = { validation::name };
-      const std::vector<std::string> optional_keys = { validation::coefficient };
+      const std::vector<std::string> optional_keys = { validation::species_name, validation::coefficient };
 
       Errors errors;
 
-      for (const auto& object : list)
+      for (auto object : list)
       {
+        BackwardCompatibleSpeciesName(object);
         auto validation_errors = ValidateSchema(object, required_keys, optional_keys);
         if (!validation_errors.empty())
         {

--- a/test/unit/development/development_unit_configs/reactions/troe/valid.json
+++ b/test/unit/development/development_unit_configs/reactions/troe/valid.json
@@ -74,6 +74,35 @@
       "kinf_C": 908.5,
       "Fc": 1.3,
       "N": 32.1
+    },
+    {
+      "type": "TROE",
+      "gas phase": "gas",
+      "name": "my troe",
+      "reactants": [
+        {
+          "species name": "C"
+        }
+      ],
+      "products": [
+        {
+          "species name": "A",
+          "coefficient": 0.2,
+          "__optional thing": "hello"
+        },
+        {
+          "species name": "B",
+          "coefficient": 1.2
+        }
+      ],
+      "k0_A": 32.1,
+      "k0_B": -2.3,
+      "k0_C": 102.3,
+      "kinf_A": 63.4,
+      "kinf_B": -1.3,
+      "kinf_C": 908.5,
+      "Fc": 1.3,
+      "N": 32.1
     }
   ]
 }

--- a/test/unit/development/development_unit_configs/reactions/troe/valid.yaml
+++ b/test/unit/development/development_unit_configs/reactions/troe/valid.yaml
@@ -33,6 +33,25 @@ reactions:
   reactants:
   - name: C
   type: TROE
+- Fc: 1.3
+  N: 32.1
+  gas phase: gas
+  k0_A: 32.1
+  k0_B: -2.3
+  k0_C: 102.3
+  kinf_A: 63.4
+  kinf_B: -1.3
+  kinf_C: 908.5
+  name: my troe
+  products:
+  - __optional thing: hello
+    coefficient: 0.2
+    species name: A
+  - coefficient: 1.2
+    species name: B
+  reactants:
+  - species name: C
+  type: TROE
 species:
 - name: A
 - name: B

--- a/test/unit/development/reactions/test_parse_troe.cpp
+++ b/test/unit/development/reactions/test_parse_troe.cpp
@@ -22,7 +22,7 @@ TEST(ParserTroe, ParseValidConfig)
     EXPECT_EQ(validation_errors.size(), 0) << "Validation errors were: " << validation_errors.size();
 
     auto mechanism = parser.Parse(object);
-    EXPECT_EQ(mechanism.reactions.troe.size(), 2);
+    EXPECT_EQ(mechanism.reactions.troe.size(), 3);
 
     EXPECT_EQ(mechanism.reactions.troe[0].gas_phase, "gas");
     EXPECT_EQ(mechanism.reactions.troe[0].k0_A, 1.0);
@@ -70,6 +70,28 @@ TEST(ParserTroe, ParseValidConfig)
     EXPECT_EQ(mechanism.reactions.troe[1].products[1].name, "B");
     EXPECT_EQ(mechanism.reactions.troe[1].products[1].coefficient, 1.2);
     EXPECT_EQ(mechanism.reactions.troe[1].products[1].unknown_properties.size(), 0);
+
+    EXPECT_EQ(mechanism.reactions.troe[2].name, "my troe");
+    EXPECT_EQ(mechanism.reactions.troe[2].gas_phase, "gas");
+    EXPECT_EQ(mechanism.reactions.troe[2].k0_A, 32.1);
+    EXPECT_EQ(mechanism.reactions.troe[2].k0_B, -2.3);
+    EXPECT_EQ(mechanism.reactions.troe[2].k0_C, 102.3);
+    EXPECT_EQ(mechanism.reactions.troe[2].kinf_A, 63.4);
+    EXPECT_EQ(mechanism.reactions.troe[2].kinf_B, -1.3);
+    EXPECT_EQ(mechanism.reactions.troe[2].kinf_C, 908.5);
+    EXPECT_EQ(mechanism.reactions.troe[2].Fc, 1.3);
+    EXPECT_EQ(mechanism.reactions.troe[2].N, 32.1);
+    EXPECT_EQ(mechanism.reactions.troe[2].reactants.size(), 1);
+    EXPECT_EQ(mechanism.reactions.troe[2].reactants[0].name, "C");
+    EXPECT_EQ(mechanism.reactions.troe[2].reactants[0].coefficient, 1);
+    EXPECT_EQ(mechanism.reactions.troe[2].products.size(), 2);
+    EXPECT_EQ(mechanism.reactions.troe[2].products[0].name, "A");
+    EXPECT_EQ(mechanism.reactions.troe[2].products[0].coefficient, 0.2);
+    EXPECT_EQ(mechanism.reactions.troe[2].products[0].unknown_properties.size(), 1);
+    EXPECT_EQ(mechanism.reactions.troe[2].products[0].unknown_properties["__optional thing"], "hello");
+    EXPECT_EQ(mechanism.reactions.troe[2].products[1].name, "B");
+    EXPECT_EQ(mechanism.reactions.troe[2].products[1].coefficient, 1.2);
+    EXPECT_EQ(mechanism.reactions.troe[2].products[1].unknown_properties.size(), 0);
   }
 }
 


### PR DESCRIPTION
This explores removing one of the breaking changes listed in #173. I'm not sure we should care about backward compatibility because it's a bear, but I figured we could explore what it *might* look like. I'm happy to abandon this PR if we decide this is a silly path to go down. We would still have a few changes to add (like converting singular objects to lists for the reactions where that changed), but i'll only do that if we decide it's worth it

Even if we abandon it, I at least want to keep the ostream changes I added for `ConfigParseStatus` because it makes it easier to read test failure information since it prints the string representation of statuses