### PR TITLE
adding gtest print information

### DIFF
--- a/include/mechanism_configuration/parse_status.hpp
+++ b/include/mechanism_configuration/parse_status.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+#include <ostream>
 
 namespace mechanism_configuration
 {
@@ -39,4 +40,10 @@ namespace mechanism_configuration
   };
 
   std::string configParseStatusToString(const ConfigParseStatus &status);
+
+  // For Google Test printing
+  inline void PrintTo(const ConfigParseStatus& status, std::ostream* os)
+  {
+    *os << configParseStatusToString(status);
+  }
 }  // namespace mechanism_configuration


### PR DESCRIPTION
Add [gtest `PrintTo`](https://google.github.io/googletest/advanced.html#teaching-googletest-how-to-print-your-values) support for config parse status. This gives us error messages like this in the log:


```
[ RUN      ] ParserTroe.DetectsBadReactionComponent
development_unit_configs/reactions/troe/bad_reaction_component.json:30:9 error: Required key 'name' is missing. RequiredKeyNotFound
development_unit_configs/reactions/troe/bad_reaction_component.json:30:9 error: Non-standard key 'Name' found. InvalidKey
/Users/kshores/Documents/MechanismConfiguration/test/unit/development/reactions/test_parse_troe.cpp:123: Failure
Expected equality of these values:
  actual
    Which is: { InvalidKey, RequiredKeyNotFound }
  expected
    Which is: { RequiredKeyNotFound }

development_unit_configs/reactions/troe/bad_reaction_component.yaml:12:5 error: Required key 'name' is missing. RequiredKeyNotFound
development_unit_configs/reactions/troe/bad_reaction_component.yaml:12:5 error: Non-standard key 'Name' found. InvalidKey
/Users/kshores/Documents/MechanismConfiguration/test/unit/development/reactions/test_parse_troe.cpp:123: Failure
Expected equality of these values:
  actual
    Which is: { InvalidKey, RequiredKeyNotFound }
  expected
    Which is: { RequiredKeyNotFound }

[  FAILED  ] ParserTroe.DetectsBadReactionComponent (1 ms)
```

Without it, we get logs like this:

```
[ RUN      ] ParserTroe.DetectsBadReactionComponent
development_unit_configs/reactions/troe/bad_reaction_component.json:30:9 error: Required key 'name' is missing. RequiredKeyNotFound
development_unit_configs/reactions/troe/bad_reaction_component.json:30:9 error: Non-standard key 'Name' found. InvalidKey
/Users/kshores/Documents/MechanismConfiguration/test/unit/development/reactions/test_parse_troe.cpp:123: Failure
Expected equality of these values:
  actual
    Which is: { 4-byte object <02-00 00-00>, 4-byte object <06-00 00-00> }
  expected
    Which is: { 4-byte object <06-00 00-00> }

development_unit_configs/reactions/troe/bad_reaction_component.yaml:12:5 error: Required key 'name' is missing. RequiredKeyNotFound
development_unit_configs/reactions/troe/bad_reaction_component.yaml:12:5 error: Non-standard key 'Name' found. InvalidKey
/Users/kshores/Documents/MechanismConfiguration/test/unit/development/reactions/test_parse_troe.cpp:123: Failure
Expected equality of these values:
  actual
    Which is: { 4-byte object <02-00 00-00>, 4-byte object <06-00 00-00> }
  expected
    Which is: { 4-byte object <06-00 00-00> }

[  FAILED  ] ParserTroe.DetectsBadReactionComponent (1 ms)
```