### PR TITLE
Correct formatter

### DIFF
--- a/include/mechanism_configuration/error_location.hpp
+++ b/include/mechanism_configuration/error_location.hpp
@@ -28,7 +28,8 @@ template<>
 struct std::formatter<mechanism_configuration::ErrorLocation>
 {
   constexpr auto parse(std::format_parse_context& ctx) const { return ctx.begin(); }
-  auto format(const mechanism_configuration::ErrorLocation& loc, std::format_context& ctx) const
+  template<class FormatContext>
+  auto format(const mechanism_configuration::ErrorLocation& loc, FormatContext& ctx) const
   {
     return std::format_to(ctx.out(), "{}:{}", loc.line, loc.column);
   }


### PR DESCRIPTION
In https://github.com/JuliaPackaging/Yggdrasil/pull/13280, I learned I had implemented the custom formatter incorrectly. This fixes the build for older versions of macos, but still seems to work with all other compilers