### PR TITLE
Build fmt as shared when needed

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -41,6 +41,10 @@ if(MECH_CONFIG_USE_FMT)
   )
 
   FetchContent_MakeAvailable(fmt)
+
+  if(fmt_POPULATED AND MECH_CONFIG_BUILD_SHARED_LIBS)
+    set_target_properties(fmt PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  endif()
 endif()
 
 ################################################################################


### PR DESCRIPTION
Setting BUILD_SHARED_LIBS globally with FORCE causes all subsequent FetchContent dependencies (e.g. TUV-x) to also build as shared, which breaks their builds if their objects lack -fPIC.

Instead, set POSITION_INDEPENDENT_CODE on the fmt target directly after fetch so fmt's static library is PIC-safe when linked into a shared mechanism_configuration, without side effects on other dependencies.