### PR TITLE
Add aerosol and cloud specific configurations

### DIFF
--- a/include/mechanism_configuration/aerosol_types.hpp
+++ b/include/mechanism_configuration/aerosol_types.hpp
@@ -1,0 +1,167 @@
+// Copyright (C) 2023–2026 University Corporation for Atmospheric Research
+//                         University of Illinois at Urbana-Champaign
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <mechanism_configuration/types.hpp>
+
+#include <functional>
+#include <map>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace mechanism_configuration::types
+{
+  // ----------------------------------------
+  // Rate constants
+  // ----------------------------------------
+
+  /// @brief Reference-temperature Arrhenius / van 't Hoff form:
+  ///        f(T) = A * exp( C * (1/T0 - 1/T) )      (C = +Ea/R, positive)
+  struct ArrheniusReferenceTemperature
+  {
+    double A;            ///< Value at the reference temperature T0 [units vary by use]
+    double C = 0.0;      ///< Temperature-dependence parameter [K] (C = +Ea/R)
+    double T0 = 298.15;  ///< Reference temperature [K]
+  };
+
+  /// @brief Equilibrium constants use the same reference-temperature form.
+  using EquilibriumConstant = ArrheniusReferenceTemperature;
+
+  /// @brief Henry's law constant: HLC(T) = HLC_ref * exp( C * (1/T - 1/T0) )
+  ///        Same van 't Hoff kernel as ArrheniusReferenceTemperature but with the
+  ///        opposite temperature trend (solubility rises as T falls)
+  struct HenryLawConstant
+  {
+    double HLC_ref;      ///< Reference HLC at T0 [mol m-3 Pa-1]
+    double C = 0.0;      ///< Temperature-dependence parameter [K]
+    double T0 = 298.15;  ///< Reference temperature [K]
+  };
+
+  /// @brief A reaction rate constant parsed from config.
+  using RateConstant = std::variant<Arrhenius, ArrheniusReferenceTemperature, std::function<double(double)>>;
+
+  // ----------------------------------------
+  // Representations
+  // ----------------------------------------
+
+  struct UniformSection
+  {
+    std::string name;
+    std::vector<std::string> phases;
+    double min_radius;   ///< Minimum section radius [m]
+    double max_radius;   ///< Maximum section radius [m]
+  };
+
+  struct SingleMomentMode
+  {
+    std::string name;
+    std::vector<std::string> phases;
+    double geometric_mean_radius;          ///< Geometric mean radius [m]
+    double geometric_standard_deviation;   ///< Geometric standard deviation [-]
+  };
+
+  struct TwoMomentMode
+  {
+    std::string name;
+    std::vector<std::string> phases;
+    double geometric_standard_deviation;   ///< Geometric standard deviation [-]
+  };
+
+  using Representation = std::variant<UniformSection, SingleMomentMode, TwoMomentMode>;
+
+  // ----------------------------------------
+  // Processes
+  // ----------------------------------------
+
+  struct DissolvedReaction
+  {
+    std::string phase;
+    std::string solvent;
+    std::vector<ReactionComponent> reactants;
+    std::vector<ReactionComponent> products;
+    /// @brief Rate constant per aerosol representation; keys are representation names.
+    std::map<std::string, RateConstant> rate_constants;
+  };
+
+  struct DissolvedReversibleReaction
+  {
+    std::string phase;
+    std::string solvent;  ///< Solvent species name (config key: "solvent")
+    std::vector<ReactionComponent> reactants;
+    std::vector<ReactionComponent> products;
+    /// @brief Per-representation forward / reverse rate constants; keys are representation names.
+    ///        Supply exactly two of {forward, reverse, equilibrium} per representation; the third is derived.
+    std::map<std::string, RateConstant> forward_rate_constants;
+    std::map<std::string, RateConstant> reverse_rate_constants;
+    /// @brief Shared, intrinsic equilibrium constant (NOT per representation).
+    std::optional<EquilibriumConstant> equilibrium_constant;
+  };
+
+  struct HenryLawPhaseTransfer
+  {
+    std::string gas_phase;
+    std::string gas_species;
+    std::string condensed_phase;
+    std::string condensed_species;
+    std::string solvent;
+    HenryLawConstant henry_law_constant;
+    HenryLawConstant henry_law_constant;
+    double diffusion_coefficient;       ///< Gas-phase diffusion coefficient [m2 s-1]
+    double accommodation_coefficient;   ///< Mass accommodation coefficient, dimensionless
+  };
+
+  using Process = std::variant<DissolvedReaction, DissolvedReversibleReaction, HenryLawPhaseTransfer>;
+
+  // ----------------------------------------
+  // Constraints
+  // ----------------------------------------
+
+  struct HenryLawEquilibrium
+  {
+    std::string gas_phase;
+    std::string gas_species;
+    std::string condensed_phase;
+    std::string condensed_species;
+    std::string solvent;
+    HenryLawConstant henry_law_constant;
+    double solvent_molecular_weight;  ///< Solvent molecular weight [kg mol-1]
+    double solvent_density;           ///< Solvent density [kg m-3]
+  };
+
+  struct DissolvedEquilibrium
+  {
+    std::string phase;
+    std::string algebraic_species;
+    std::string solvent;
+    std::vector<ReactionComponent> reactants;
+    std::vector<ReactionComponent> products;
+    EquilibriumConstant equilibrium_constant;
+  };
+
+  struct LinearConstraintTerm
+  {
+    std::string phase;
+    std::string species;
+    double coefficient;
+  };
+
+  /// @brief RHS constant C of a LinearConstraint:  G = sum(coeff_i * [species_i]) - C = 0
+  ///        Choose exactly one mode (mutually exclusive):
+  struct FixedConstant     { double value = 0.0; };   ///< Fixed value [mol m-3], shared by all instances
+  struct DiagnoseFromState {};                        ///< Computed per representation instance
+
+  struct LinearConstraint
+  {
+    std::string algebraic_phase;
+    std::string algebraic_species;
+    std::vector<LinearConstraintTerm> terms;
+    std::variant<FixedConstant, DiagnoseFromState> constant = FixedConstant{ 0.0 };
+  };
+
+  using Constraint = std::variant<HenryLawEquilibrium, DissolvedEquilibrium, LinearConstraint>;
+
+}  // namespace mechanism_configuration::types

--- a/include/mechanism_configuration/aerosol_types.hpp
+++ b/include/mechanism_configuration/aerosol_types.hpp
@@ -19,7 +19,7 @@ namespace mechanism_configuration::types
   // Rate constants
   // ----------------------------------------
 
-  /// @brief Reference-temperature Arrhenius / van 't Hoff form:
+  /// @brief Reference-temperature Arrhenius
   ///        f(T) = A * exp( C * (1/T0 - 1/T) )      (C = +Ea/R, positive)
   struct ArrheniusReferenceTemperature
   {
@@ -32,7 +32,7 @@ namespace mechanism_configuration::types
   using EquilibriumConstant = ArrheniusReferenceTemperature;
 
   /// @brief Henry's law constant: HLC(T) = HLC_ref * exp( C * (1/T - 1/T0) )
-  ///        Same van 't Hoff kernel as ArrheniusReferenceTemperature but with the
+  ///        Same as ArrheniusReferenceTemperature but with the
   ///        opposite temperature trend (solubility rises as T falls)
   struct HenryLawConstant
   {
@@ -52,23 +52,23 @@ namespace mechanism_configuration::types
   {
     std::string name;
     std::vector<std::string> phases;
-    double min_radius;   ///< Minimum section radius [m]
-    double max_radius;   ///< Maximum section radius [m]
+    double min_radius;   ///< [m]
+    double max_radius;   ///< [m]
   };
 
   struct SingleMomentMode
   {
     std::string name;
     std::vector<std::string> phases;
-    double geometric_mean_radius;          ///< Geometric mean radius [m]
-    double geometric_standard_deviation;   ///< Geometric standard deviation [-]
+    double geometric_mean_radius;          ///< [m]
+    double geometric_standard_deviation;   ///< dimensionless
   };
 
   struct TwoMomentMode
   {
     std::string name;
     std::vector<std::string> phases;
-    double geometric_standard_deviation;   ///< Geometric standard deviation [-]
+    double geometric_standard_deviation;   ///< dimensionless
   };
 
   using Representation = std::variant<UniformSection, SingleMomentMode, TwoMomentMode>;
@@ -90,7 +90,7 @@ namespace mechanism_configuration::types
   struct DissolvedReversibleReaction
   {
     std::string phase;
-    std::string solvent;  ///< Solvent species name (config key: "solvent")
+    std::string solvent;
     std::vector<ReactionComponent> reactants;
     std::vector<ReactionComponent> products;
     /// @brief Per-representation forward / reverse rate constants; keys are representation names.
@@ -128,8 +128,8 @@ namespace mechanism_configuration::types
     std::string condensed_species;
     std::string solvent;
     HenryLawConstant henry_law_constant;
-    double solvent_molecular_weight;  ///< Solvent molecular weight [kg mol-1]
-    double solvent_density;           ///< Solvent density [kg m-3]
+    double solvent_molecular_weight;  ///< [kg mol-1]
+    double solvent_density;           ///< [kg m-3]
   };
 
   struct DissolvedEquilibrium

--- a/src/detail/v1/aerosol_keys.hpp
+++ b/src/detail/v1/aerosol_keys.hpp
@@ -1,0 +1,90 @@
+// Copyright (C) 2023–2026 University Corporation for Atmospheric Research
+//                         University of Illinois at Urbana-Champaign
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string_view>
+
+namespace mechanism_configuration::v1::keys
+{
+  // ----------------------------------------
+  // Top-level containers
+  // ----------------------------------------
+  inline constexpr std::string_view aerosol_representations = "aerosol representations";
+  inline constexpr std::string_view aerosol_processes = "aerosol processes";
+
+  // ----------------------------------------
+  // Representations
+  // ----------------------------------------
+  // also: name, phases
+
+  inline constexpr std::string_view UniformSection_key = "UNIFORM_SECTION";
+  inline constexpr std::string_view minimum_radius = "minimum radius [m]";
+  inline constexpr std::string_view maximum_radius = "maximum radius [m]";
+
+  inline constexpr std::string_view SingleMomentMode_key = "SINGLE_MOMENT_MODE";
+  inline constexpr std::string_view geometric_mean_radius = "geometric mean radius [m]";
+  inline constexpr std::string_view geometric_standard_deviation = "geometric standard deviation [-]";
+
+  inline constexpr std::string_view TwoMomentMode_key = "TWO_MOMENT_MODE";
+  // also: geometric_standard_deviation
+
+  // ----------------------------------------
+  // Rate constants
+  // ----------------------------------------
+  inline constexpr std::string_view rate_constants = "rate constants";
+  inline constexpr std::string_view forward_rate_constants = "forward rate constants";
+  inline constexpr std::string_view reverse_rate_constants = "reverse rate constants";
+  inline constexpr std::string_view equilibrium_constant = "equilibrium constant";
+  inline constexpr std::string_view reference_temperature = "T0 [K]";
+
+  inline constexpr std::string_view henry_law_constant = "Henry's law constant";
+  inline constexpr std::string_view HLC_ref = "HLC_ref [mol m-3 Pa-1]";
+  inline constexpr std::string_view henry_law_C = "C [K]";
+
+  // ----------------------------------------
+  // Processes
+  // ----------------------------------------
+  inline constexpr std::string_view solvent = "solvent";
+
+  // HenryLawPhaseTransfer
+  // also: gas_phase, gas_phase_species, condensed_phase, condensed_phase_species, solvent,
+  //       henry_law_constant, diffusion_coefficient
+  inline constexpr std::string_view HenryLawPhaseTransfer_key = "HENRY_LAW_PHASE_TRANSFER";
+  inline constexpr std::string_view accommodation_coefficient = "accommodation coefficient [-]";
+
+  // DissolvedReaction
+  // also: condensed_phase, solvent, reactants, products, rate_constants
+  inline constexpr std::string_view DissolvedReaction_key = "DISSOLVED_REACTION";
+
+  // DissolvedReversibleReaction
+  // also: condensed_phase, solvent, reactants, products,
+  //       forward_rate_constants, reverse_rate_constants, equilibrium_constant
+  inline constexpr std::string_view DissolvedReversibleReaction_key = "DISSOLVED_REVERSIBLE_REACTION";
+
+  // ----------------------------------------
+  // Constraints
+  // ----------------------------------------
+  // HenryLawEquilibrium
+  // also: gas_phase, gas_phase_species, condensed_phase, condensed_phase_species, solvent,
+  //       henry_law_constant
+  inline constexpr std::string_view HenryLawEquilibrium_key = "HENRY_LAW_EQUILIBRIUM";
+  inline constexpr std::string_view solvent_molecular_weight = "solvent molecular weight [kg mol-1]";
+  inline constexpr std::string_view solvent_density = "solvent density [kg m-3]";
+
+  // DissolvedEquilibrium
+  // also: condensed_phase, solvent, reactants, products, equilibrium_constant
+  inline constexpr std::string_view DissolvedEquilibrium_key = "DISSOLVED_EQUILIBRIUM";
+  inline constexpr std::string_view algebraic_species = "algebraic species";
+
+  // LinearConstraint
+  // also: name; terms carry coefficient and species
+  inline constexpr std::string_view LinearConstraint_key = "LINEAR_CONSTRAINT";
+  inline constexpr std::string_view algebraic_phase = "algebraic phase";
+  inline constexpr std::string_view terms = "terms";
+  inline constexpr std::string_view phase = "phase";
+  inline constexpr std::string_view constant = "constant [mol m-3]";
+  inline constexpr std::string_view diagnose_from_state = "diagnose from state";
+
+}  // namespace mechanism_configuration::v1::keys

--- a/test/integration/integration_configs/cam_clound_chemistry.json
+++ b/test/integration/integration_configs/cam_clound_chemistry.json
@@ -103,10 +103,10 @@
         { "species": "H2O",     "coefficient": 1 }
       ],
       "forward rate constants": {
-        "CLOUD": { "type": "ARRHENIUS_REFERENCE_T", "A": 3.184e8, "C [K]": 4430.0, "T0 [K]": 298.15 }
+        "CLOUD": { "type": "ARRHENIUS", "A": 3.184e8,  "C": 4430.0 }
       },
       "equilibrium constant": {
-        "type": "ARRHENIUS_REFERENCE_T", "A": 1725.0, "C [K]": 0.0, "T0 [K]": 298.15
+        "type": "ARRHENIUS_REFERENCE_TEMPERATURE", "A": 1725.0, "C [K]": 0.0, "T0 [K]": 298.15
       }
     },
     {
@@ -123,7 +123,7 @@
         { "species name": "SO4mm", "coefficient": 1 }
       ],
       "rate constants": {
-        "CLOUD": { "type": "ARRHENIUS_REFERENCE_T", "A": 1.333e8, "C [K]": 4430.0, "T0 [K]": 298.15 }
+        "CLOUD": { "type": "ARRHENIUS", "A": 1.333e8, "C": 4430.0}
       }
     },
     {
@@ -140,7 +140,7 @@
       ],
       "algebraic species": "OHm",
       "equilibrium constant": {
-        "type": "ARRHENIUS_REFERENCE_T", "A": 3.24e-18, "C [K]": 0.0, "T0 [K]": 298.15
+        "type": "ARRHENIUS_REFERENCE_TEMPERATURE", "A": 3.24e-18, "C [K]": 0.0, "T0 [K]": 298.15
       }
     },
     {
@@ -157,13 +157,14 @@
       ],
       "algebraic species": "HSO3m",
       "equilibrium constant": {
-        "type": "ARRHENIUS_REFERENCE_T", "A": 3.06e-4, "C [K]": 2090.0, "T0 [K]": 298.15
+        "type": "ARRHENIUS_REFERENCE_TEMPERATURE", "A": 3.06e-4, "C [K]": 2090.0, "T0 [K]": 298.15
       }
     },
     {
       "__comment": "Ka2: HSO3- <-> H+ + SO3--",
       "type": "DISSOLVED_EQUILIBRIUM",
       "condensed phase": "AQUEOUS",
+      "algebraic species": "SO3mm",
       "solvent": "H2O",
       "reactants": [
         { "species": "HSO3m", "coefficient": 1 }
@@ -172,9 +173,8 @@
         { "species": "Hp",    "coefficient": 1 },
         { "species": "SO3mm", "coefficient": 1 }
       ],
-      "algebraic species": "SO3mm",
       "equilibrium constant": {
-        "type": "ARRHENIUS_REFERENCE_T", "A": 1.08e-9, "C [K]": 1120.0, "T0 [K]": 298.15
+        "type": "ARRHENIUS_REFERENCE_TEMPERATURE", "A": 1.08e-9, "C [K]": 1120.0, "T0 [K]": 298.15
       }
     },
     {

--- a/test/integration/integration_configs/cam_clound_chemistry.json
+++ b/test/integration/integration_configs/cam_clound_chemistry.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.2.0",
   "name": "CAM Cloud Chemistry",
 
   "species": [

--- a/test/integration/integration_configs/cam_clound_chemistry.json
+++ b/test/integration/integration_configs/cam_clound_chemistry.json
@@ -56,7 +56,8 @@
       "solvent": "H2O",
       "Henry's law constant": {
         "HLC_ref [mol m-3 Pa-1]": 1.214e-2,
-        "C [K]": 3120.0
+        "C [K]": 3120.0,
+        "T0 [K]": 298.15
       }
     },
     {
@@ -69,7 +70,8 @@
       "solvent": "H2O",
       "Henry's law constant": {
         "HLC_ref [mol m-3 Pa-1]": 7.306e2,
-        "C [K]": 6621.0
+        "C [K]": 6621.0,
+        "T0 [K]": 298.15
       }
     },
     {
@@ -82,7 +84,8 @@
       "solvent": "H2O",
       "Henry's law constant": {
         "HLC_ref [mol m-3 Pa-1]": 1.135e-4,
-        "C [K]": 2560.0
+        "C [K]": 2560.0,
+        "T0 [K]": 298.15
       }
     },
     {
@@ -100,10 +103,10 @@
         { "species": "H2O",     "coefficient": 1 }
       ],
       "forward rate constants": {
-        "CLOUD": { "A": 3.184e8, "C": 4430.0 }
+        "CLOUD": { "type": "ARRHENIUS_REFERENCE_T", "A": 3.184e8, "C [K]": 4430.0, "T0 [K]": 298.15 }
       },
       "equilibrium constant": {
-        "A": 1725.0
+        "type": "ARRHENIUS_REFERENCE_T", "A": 1725.0, "C [K]": 0.0, "T0 [K]": 298.15
       }
     },
     {
@@ -120,7 +123,7 @@
         { "species name": "SO4mm", "coefficient": 1 }
       ],
       "rate constants": {
-        "CLOUD": { "A": 1.333e8, "C": 4430.0 }
+        "CLOUD": { "type": "ARRHENIUS_REFERENCE_T", "A": 1.333e8, "C [K]": 4430.0, "T0 [K]": 298.15 }
       }
     },
     {
@@ -137,8 +140,7 @@
       ],
       "algebraic species": "OHm",
       "equilibrium constant": {
-        "A": 3.24e-18,
-        "C": 0.0
+        "type": "ARRHENIUS_REFERENCE_T", "A": 3.24e-18, "C [K]": 0.0, "T0 [K]": 298.15
       }
     },
     {
@@ -155,8 +157,7 @@
       ],
       "algebraic species": "HSO3m",
       "equilibrium constant": {
-        "A": 3.06e-4,
-        "C": 2090.0
+        "type": "ARRHENIUS_REFERENCE_T", "A": 3.06e-4, "C [K]": 2090.0, "T0 [K]": 298.15
       }
     },
     {
@@ -173,8 +174,7 @@
       ],
       "algebraic species": "SO3mm",
       "equilibrium constant": {
-        "A": 1.08e-9,
-        "C": 1120.0
+        "type": "ARRHENIUS_REFERENCE_T", "A": 1.08e-9, "C [K]": 1120.0, "T0 [K]": 298.15
       }
     },
     {

--- a/test/integration/integration_configs/cam_clound_chemistry.json
+++ b/test/integration/integration_configs/cam_clound_chemistry.json
@@ -1,0 +1,232 @@
+{
+  "version": "1.0.0",
+  "name": "CAM Cloud Chemistry",
+
+  "species": [
+    { "name": "SO2",     "molecular weight [kg mol-1]": 0.06407 },
+    { "name": "H2O2",    "molecular weight [kg mol-1]": 0.03401 },
+    { "name": "O3",      "molecular weight [kg mol-1]": 0.04800 },
+    { "name": "Hp",      "molecular weight [kg mol-1]": 0.00101 },
+    { "name": "OHm",     "molecular weight [kg mol-1]": 0.01701 },
+    { "name": "HSO3m",   "molecular weight [kg mol-1]": 0.08107 },
+    { "name": "SO3mm",   "molecular weight [kg mol-1]": 0.08007 },
+    { "name": "SO4mm",   "molecular weight [kg mol-1]": 0.09607 },
+    { "name": "SO2OOHm", "molecular weight [kg mol-1]": 0.11307 },
+    { "name": "H2O",     "molecular weight [kg mol-1]": 0.01801 }
+  ],
+
+  "phases": [
+    {
+      "name": "gas",
+      "species": [
+        { "name": "SO2",  "diffusion coefficient [m2 s-1]": 1.28e-5 },
+        { "name": "H2O2", "diffusion coefficient [m2 s-1]": 1.46e-5 },
+        { "name": "O3",   "diffusion coefficient [m2 s-1]": 1.48e-5 }
+      ]
+    },
+    {
+      "name": "AQUEOUS",
+      "species": [
+        "SO2", "H2O2", "O3", "Hp", "OHm", "HSO3m", "SO3mm", "SO4mm", "SO2OOHm",
+        { "name": "H2O", "density [kg m-3]": 997.0 }
+      ]
+    }
+  ],
+
+  "reactions": [],
+
+  "aerosol representations": [
+    {
+      "type": "UNIFORM_SECTION",
+      "name": "CLOUD",
+      "phases": ["AQUEOUS"],
+      "minimum radius [m]": 1.0e-6,
+      "maximum radius [m]": 1.0e-5
+    }
+  ],
+
+  "aerosol processes": [
+    {
+      "__comment": "Henry's Law Equilibrium: SO2(g) <-> SO2(aq)",
+      "type": "HENRY_LAW_EQUILIBRIUM",
+      "gas phase": "gas",
+      "gas-phase species": "SO2",
+      "condensed phase": "AQUEOUS",
+      "condensed-phase species": "SO2",
+      "solvent": "H2O",
+      "Henry's law constant": {
+        "HLC_ref [mol m-3 Pa-1]": 1.214e-2,
+        "C [K]": 3120.0
+      }
+    },
+    {
+      "__comment": "Henry's Law Equilibrium: H2O2(g) <-> H2O2(aq)",
+      "type": "HENRY_LAW_EQUILIBRIUM",
+      "gas phase": "gas",
+      "gas-phase species": "H2O2",
+      "condensed phase": "AQUEOUS",
+      "condensed-phase species": "H2O2",
+      "solvent": "H2O",
+      "Henry's law constant": {
+        "HLC_ref [mol m-3 Pa-1]": 7.306e2,
+        "C [K]": 6621.0
+      }
+    },
+    {
+      "__comment": "Henry's Law Equilibrium: O3(g) <-> O3(aq)",
+      "type": "HENRY_LAW_EQUILIBRIUM",
+      "gas phase": "gas",
+      "gas-phase species": "O3",
+      "condensed phase": "AQUEOUS",
+      "condensed-phase species": "O3",
+      "solvent": "H2O",
+      "Henry's law constant": {
+        "HLC_ref [mol m-3 Pa-1]": 1.135e-4,
+        "C [K]": 2560.0
+      }
+    },
+    {
+      "__comment": "R1a: HSO3- + H2O2_aq <-> SO2OOH- + H2O (reversible, Keq=1725)",
+      "__note": "k_fwd = c_H2O_M * 7.45e7/13 = 3.184e8; Keq=1725 (Lind & Kok 1986 / revised MIAM)",
+      "type": "DISSOLVED_REVERSIBLE_REACTION",
+      "condensed phase": "AQUEOUS",
+      "solvent": "H2O",
+      "reactants": [
+        { "species": "HSO3m", "coefficient": 1 },
+        { "species": "H2O2",  "coefficient": 1 }
+      ],
+      "products": [
+        { "species": "SO2OOHm", "coefficient": 1 },
+        { "species": "H2O",     "coefficient": 1 }
+      ],
+      "forward rate constants": {
+        "CLOUD": { "A": 3.184e8, "C": 4430.0 }
+      },
+      "equilibrium constant": {
+        "A": 1725.0
+      }
+    },
+    {
+      "__comment": "R1b: SO2OOH- + H+ -> SO4-- (irreversible)",
+      "__note": "k = c_H2O_M * 2.4e6 = 1.333e8; Ea/R = 4430 K",
+      "type": "DISSOLVED_REACTION",
+      "condensed phase": "AQUEOUS",
+      "solvent": "H2O",
+      "reactants": [
+        { "species name": "SO2OOHm", "coefficient": 1 },
+        { "species name": "Hp",      "coefficient": 1 }
+      ],
+      "products": [
+        { "species name": "SO4mm", "coefficient": 1 }
+      ],
+      "rate constants": {
+        "CLOUD": { "A": 1.333e8, "C": 4430.0 }
+      }
+    },
+    {
+      "__comment": "Kw: 2 H2O <-> H+ + OH-",
+      "type": "DISSOLVED_EQUILIBRIUM",
+      "condensed phase": "AQUEOUS",
+      "solvent": "H2O",
+      "reactants": [
+        { "species": "H2O", "coefficient": 2 }
+      ],
+      "products": [
+        { "species": "Hp",  "coefficient": 1 },
+        { "species": "OHm", "coefficient": 1 }
+      ],
+      "algebraic species": "OHm",
+      "equilibrium constant": {
+        "A": 3.24e-18,
+        "C": 0.0
+      }
+    },
+    {
+      "__comment": "Ka1: SO2(aq) <-> H+ + HSO3-",
+      "type": "DISSOLVED_EQUILIBRIUM",
+      "condensed phase": "AQUEOUS",
+      "solvent": "H2O",
+      "reactants": [
+        { "species": "SO2", "coefficient": 1 }
+      ],
+      "products": [
+        { "species": "Hp",    "coefficient": 1 },
+        { "species": "HSO3m", "coefficient": 1 }
+      ],
+      "algebraic species": "HSO3m",
+      "equilibrium constant": {
+        "A": 3.06e-4,
+        "C": 2090.0
+      }
+    },
+    {
+      "__comment": "Ka2: HSO3- <-> H+ + SO3--",
+      "type": "DISSOLVED_EQUILIBRIUM",
+      "condensed phase": "AQUEOUS",
+      "solvent": "H2O",
+      "reactants": [
+        { "species": "HSO3m", "coefficient": 1 }
+      ],
+      "products": [
+        { "species": "Hp",    "coefficient": 1 },
+        { "species": "SO3mm", "coefficient": 1 }
+      ],
+      "algebraic species": "SO3mm",
+      "equilibrium constant": {
+        "A": 1.08e-9,
+        "C": 1120.0
+      }
+    },
+    {
+      "__comment": "Mass conservation: total sulfur in reversible pool (includes SO2OOH-)",
+      "type": "LINEAR_CONSTRAINT",
+      "algebraic phase": "gas",
+      "algebraic species": "SO2",
+      "diagnose from state": true,
+      "terms": [
+        { "phase": "gas",     "species": "SO2",      "coefficient": 1.0 },
+        { "phase": "AQUEOUS", "species": "SO2",      "coefficient": 1.0 },
+        { "phase": "AQUEOUS", "species": "HSO3m",    "coefficient": 1.0 },
+        { "phase": "AQUEOUS", "species": "SO3mm",    "coefficient": 1.0 },
+        { "phase": "AQUEOUS", "species": "SO2OOHm",  "coefficient": 1.0 }
+      ]
+    },
+    {
+      "__comment": "Mass conservation: total H2O2",
+      "type": "LINEAR_CONSTRAINT",
+      "algebraic phase": "gas",
+      "algebraic species": "H2O2",
+      "diagnose from state": true,
+      "terms": [
+        { "phase": "gas",     "species": "H2O2", "coefficient": 1.0 },
+        { "phase": "AQUEOUS", "species": "H2O2", "coefficient": 1.0 }
+      ]
+    },
+    {
+      "__comment": "Mass conservation: total O3",
+      "type": "LINEAR_CONSTRAINT",
+      "algebraic phase": "gas",
+      "algebraic species": "O3",
+      "diagnose from state": true,
+      "terms": [
+        { "phase": "gas",     "species": "O3", "coefficient": 1.0 },
+        { "phase": "AQUEOUS", "species": "O3", "coefficient": 1.0 }
+      ]
+    },
+    {
+      "__comment": "Charge balance: H+ = OH- + HSO3- + 2 SO3-- + 2 SO4-- + SO2OOH-",
+      "type": "LINEAR_CONSTRAINT",
+      "algebraic phase": "AQUEOUS",
+      "algebraic species": "Hp",
+      "constant [mol m-3]": 0.0,
+      "terms": [
+        { "phase": "AQUEOUS", "species": "Hp",       "coefficient":  1.0 },
+        { "phase": "AQUEOUS", "species": "OHm",      "coefficient": -1.0 },
+        { "phase": "AQUEOUS", "species": "HSO3m",    "coefficient": -1.0 },
+        { "phase": "AQUEOUS", "species": "SO3mm",    "coefficient": -2.0 },
+        { "phase": "AQUEOUS", "species": "SO4mm",    "coefficient": -2.0 },
+        { "phase": "AQUEOUS", "species": "SO2OOHm",  "coefficient": -1.0 }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR:
- Part of #271
  - Adds aerosol specific keys, structs and configurations.  
- Related PR:   https://github.com/NCAR/miam/pull/65

- Cleans up the CAM cloud chemistry configuration. This includes:
  - Clarifying the rate constant type. the literal `rate constant` is ambiguous. Based on the implementation, the type is specified as below:

```JSON
// Current
"rate constants": {
        "CLOUD": { "A": 1.333e8, "C": 4430.0 }

// This PR
"rate constants": {
        "CLOUD": { "type": "ARRHENIUS", "A": 1.333e8, "C": 4430.0}
      }
```
  - The configuration defines equilibrium constants using Arrhenius-style parameters but, the implementation is in the form of a van't Hoff formulation to compute the temperature-dependent equilibrium constant. 
The updated configuration now reflect this behavior explicitly.
```JSON
// Current
"equilibrium constant": {
        "A": 1.08e-9,
        "C": 1120.0 }

// This PR
"equilibrium constant": {
        "type": "ARRHENIUS_REFERENCE_TEMPERATURE", "A": 1.08e-9, "C [K]": 1120.0, "T0 [K]": 298.15 }
```