### PR TITLE
Fix code coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,10 @@ if(PROJECT_IS_TOP_LEVEL AND MECH_CONFIG_ENABLE_TESTS)
     setup_target_for_coverage_lcov(
         NAME coverage
         EXECUTABLE "ctest" -j 4
-        EXCLUDE "${PROJECT_SOURCE_DIR}/test/*"
+        EXCLUDE
+            "${PROJECT_SOURCE_DIR}/test/*"
+            "${CMAKE_BINARY_DIR}/_deps/*"
+            "/usr/*"
         BASE_DIRECTORY "${PROJECT_SOURCE_DIR}/src"
         LCOV_ARGS --ignore-errors mismatch)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,19 @@ set(MECH_CONFIG_LIB_DIR ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
 include(cmake/dependencies.cmake)
 
 ################################################################################
+# Code coverage instrumentation
+#
+# These flags must be applied BEFORE add_subdirectory(src) so the library
+# targets are compiled with coverage instrumentation. append_coverage_compiler_flags()
+# only affects targets defined after it runs, so calling it later would leave the
+# library uninstrumented and the report would cover almost nothing.
+
+if(PROJECT_IS_TOP_LEVEL AND MECH_CONFIG_ENABLE_TESTS AND MECH_CONFIG_ENABLE_COVERAGE)
+  include(cmake/CodeCoverage.cmake)
+  append_coverage_compiler_flags()
+endif()
+
+################################################################################
 # project source code
 
 add_subdirectory(src)
@@ -49,8 +62,6 @@ add_subdirectory(src)
 if(PROJECT_IS_TOP_LEVEL AND MECH_CONFIG_ENABLE_TESTS)
   # Test code coverage
   if(MECH_CONFIG_ENABLE_COVERAGE)
-    include(cmake/CodeCoverage.cmake)
-    append_coverage_compiler_flags()
     setup_target_for_coverage_lcov(
         NAME coverage
         EXECUTABLE "ctest" -j 4

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -158,7 +158,7 @@ elseif(NOT CMAKE_COMPILER_IS_GNUCXX)
     endif()
 endif()
 
-set(COVERAGE_COMPILER_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage -fcheck=bounds,do,pointer -ffpe-trap=zero,overflow,invalid"
+set(COVERAGE_COMPILER_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage"
     CACHE INTERNAL "")
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     include(CheckCXXCompilerFlag)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+
+# Backstop in addition to the lcov --remove excludes in CMakeLists.txt.
+# Keeps third-party and test code out of the coverage totals.
+ignore:
+  - "test/**/*"
+  - "build/_deps/**/*"
+  - "**/_deps/**/*"
+  - "examples/**/*"
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default


### PR DESCRIPTION
Fix code coverage

- `append_coverage_compiler_flags()` was being added after the call to add the library
- removed fortran-only compiler flags
- added [codecov.yml](https://docs.codecov.com/docs/codecov-yaml) to properly configure codecov
  - excludes test, build dependencies