### PR TITLE
add parser accepting string config

### DIFF
--- a/include/mechanism_configuration/errors.hpp
+++ b/include/mechanism_configuration/errors.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <mechanism_configuration/format_compat.hpp>
-
 #include <ostream>
 #include <string>
 #include <utility>
@@ -65,33 +63,3 @@ namespace mechanism_configuration
 
   using Errors = std::vector<std::pair<ErrorCode, std::string>>;
 }  // namespace mechanism_configuration
-
-#ifdef MECH_CONFIG_USE_FMT
-template<>
-struct fmt::formatter<mechanism_configuration::ErrorLocation>
-{
-  constexpr auto parse(fmt::format_parse_context& ctx) const
-  {
-    return ctx.begin();
-  }
-  template<class FormatContext>
-  auto format(const mechanism_configuration::ErrorLocation& loc, FormatContext& ctx) const
-  {
-    return fmt::format_to(ctx.out(), "{}:{}", loc.line, loc.column);
-  }
-};
-#else
-template<>
-struct std::formatter<mechanism_configuration::ErrorLocation>
-{
-  constexpr auto parse(std::format_parse_context& ctx) const
-  {
-    return ctx.begin();
-  }
-  template<class FormatContext>
-  auto format(const mechanism_configuration::ErrorLocation& loc, FormatContext& ctx) const
-  {
-    return std::format_to(ctx.out(), "{}:{}", loc.line, loc.column);
-  }
-};
-#endif

--- a/include/mechanism_configuration/mechanism_configuration.hpp
+++ b/include/mechanism_configuration/mechanism_configuration.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <mechanism_configuration/errors.hpp>
-#include <mechanism_configuration/format_compat.hpp>
 #include <mechanism_configuration/mechanism.hpp>
 #include <mechanism_configuration/parse.hpp>
 #include <mechanism_configuration/types.hpp>

--- a/include/mechanism_configuration/parse.hpp
+++ b/include/mechanism_configuration/parse.hpp
@@ -9,6 +9,7 @@
 
 #include <expected>
 #include <filesystem>
+#include <string>
 
 namespace mechanism_configuration
 {
@@ -17,4 +18,5 @@ namespace mechanism_configuration
   ///        or a directory of version-0 CAMP files.
   /// @return The parsed Mechanism, or all structural and semantic errors encountered.
   std::expected<Mechanism, Errors> Parse(const std::filesystem::path& config_path);
+  std::expected<Mechanism, Errors> ParseFromString(const std::string& config);
 }  // namespace mechanism_configuration

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,8 +13,8 @@ add_library(musica::mechanism_configuration ALIAS mechanism_configuration)
 target_compile_features(mechanism_configuration PUBLIC cxx_std_23)
 
 if(MECH_CONFIG_USE_FMT)
-  target_compile_definitions(mechanism_configuration PUBLIC MECH_CONFIG_USE_FMT)
-  target_link_libraries(mechanism_configuration PUBLIC fmt::fmt)
+  target_compile_definitions(mechanism_configuration PRIVATE MECH_CONFIG_USE_FMT)
+  target_link_libraries(mechanism_configuration PRIVATE fmt::fmt)
 endif()
 
 set_target_properties(mechanism_configuration PROPERTIES

--- a/src/check_schema.cpp
+++ b/src/check_schema.cpp
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "detail/check_schema.hpp"
-
-#include <mechanism_configuration/format_compat.hpp>
+#include "detail/error_format.hpp"
 
 #include <iostream>
 

--- a/src/detail/error_format.hpp
+++ b/src/detail/error_format.hpp
@@ -1,0 +1,41 @@
+// Copyright (C) 2023–2026 University Corporation for Atmospheric Research
+//                         University of Illinois at Urbana-Champaign
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <mechanism_configuration/errors.hpp>
+#include <mechanism_configuration/format_compat.hpp>
+
+// Formatter for ErrorLocation. Kept internal (not in the public errors.hpp) so that
+// fmt / <format> is not pulled into the library's public interface. Only the .cpp
+// files that build error-message strings need this, so it lives under src/detail.
+#ifdef MECH_CONFIG_USE_FMT
+template<>
+struct fmt::formatter<mechanism_configuration::ErrorLocation>
+{
+  constexpr auto parse(fmt::format_parse_context& ctx) const
+  {
+    return ctx.begin();
+  }
+  template<class FormatContext>
+  auto format(const mechanism_configuration::ErrorLocation& loc, FormatContext& ctx) const
+  {
+    return fmt::format_to(ctx.out(), "{}:{}", loc.line, loc.column);
+  }
+};
+#else
+template<>
+struct std::formatter<mechanism_configuration::ErrorLocation>
+{
+  constexpr auto parse(std::format_parse_context& ctx) const
+  {
+    return ctx.begin();
+  }
+  template<class FormatContext>
+  auto format(const mechanism_configuration::ErrorLocation& loc, FormatContext& ctx) const
+  {
+    return std::format_to(ctx.out(), "{}:{}", loc.line, loc.column);
+  }
+};
+#endif

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -90,4 +90,28 @@ namespace mechanism_configuration
     }
   }
 
+  std::expected<Mechanism, Errors> ParseFromString(const std::string& config)
+  {
+    // only v1 supports parsing from a string, so we must first detect the version from the string
+    YAML::Node object;
+    try
+    {
+      object = YAML::Load(config);
+      if (!object["version"])
+      {
+        return std::unexpected(Errors{ { ErrorCode::InvalidVersion, "error: Unsupported version number '0.0.0'." } });
+      }
+      const Version version(object["version"].as<std::string>());
+      if (version.major != 1)
+      {
+        return std::unexpected(Errors{ { ErrorCode::InvalidVersion, mc_fmt::format("error: Unsupported version number '{}'.", version.to_string()) } });
+      }
+      return v1::Parser{}.Parse(config);
+    }
+    catch (const YAML::Exception& e)
+    {
+      return std::unexpected(Errors{ { ErrorCode::UnexpectedError, mc_fmt::format("Failed to parse configuration string: {}", e.what()) } });
+    }
+  }
+
 }  // namespace mechanism_configuration

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -2,11 +2,11 @@
 //                         University of Illinois at Urbana-Champaign
 // SPDX-License-Identifier: Apache-2.0
 
+#include "detail/error_format.hpp"
 #include "detail/v0/parser.hpp"
 #include "detail/v1/parser.hpp"
 
 #include <mechanism_configuration/errors.hpp>
-#include <mechanism_configuration/format_compat.hpp>
 #include <mechanism_configuration/mechanism.hpp>
 #include <mechanism_configuration/parse.hpp>
 

--- a/src/v0/emission_parser.cpp
+++ b/src/v0/emission_parser.cpp
@@ -23,16 +23,15 @@ namespace mechanism_configuration::v0
     {
       std::string species = object[keys::SPECIES].as<std::string>();
       YAML::Node products_object{};
-      std::vector<types::ReactionComponent> reactants;
       std::vector<types::ReactionComponent> products;
       products.push_back({ .name = species, .coefficient = 1.0 });
       double scaling_factor = object[keys::SCALING_FACTOR] ? object[keys::SCALING_FACTOR].as<double>() : 1.0;
 
-      std::string name = "EMIS." + object[keys::MUSICA_NAME].as<std::string>();
-      types::UserDefined user_defined = {
-        .scaling_factor = scaling_factor, .reactants = reactants, .products = products, .name = name
+      std::string name = object[keys::MUSICA_NAME].as<std::string>();
+      types::Emission user_defined = {
+        .scaling_factor = scaling_factor, .products = products, .name = name
       };
-      mechanism.reactions.user_defined.push_back(user_defined);
+      mechanism.reactions.emission.push_back(user_defined);
     }
 
     return errors;

--- a/src/v0/first_order_loss_parser.cpp
+++ b/src/v0/first_order_loss_parser.cpp
@@ -29,11 +29,11 @@ namespace mechanism_configuration::v0
       reactants.push_back({ .name = species, .coefficient = 1.0 });
       double scaling_factor = object[keys::SCALING_FACTOR] ? object[keys::SCALING_FACTOR].as<double>() : 1.0;
 
-      std::string name = "LOSS." + object[keys::MUSICA_NAME].as<std::string>();
-      types::UserDefined user_defined = {
-        .scaling_factor = scaling_factor, .reactants = reactants, .products = products, .name = name
+      std::string name = object[keys::MUSICA_NAME].as<std::string>();
+      types::FirstOrderLoss user_defined = {
+        .scaling_factor = scaling_factor, .reactants = reactants[0], .products = products, .name = name
       };
-      mechanism.reactions.user_defined.push_back(user_defined);
+      mechanism.reactions.first_order_loss.push_back(user_defined);
     }
 
     return errors;

--- a/src/v0/parser.cpp
+++ b/src/v0/parser.cpp
@@ -171,7 +171,7 @@ namespace mechanism_configuration::v0
 
       // all species in version 0 are in the gas phase
       types::Phase gas_phase;
-      gas_phase.name = "GAS";
+      gas_phase.name = "gas";
       for (auto& species : mechanism.species)
       {
         types::PhaseSpecies phase_species;

--- a/src/v0/photolysis_parser.cpp
+++ b/src/v0/photolysis_parser.cpp
@@ -32,11 +32,11 @@ namespace mechanism_configuration::v0
 
       double scaling_factor = object[keys::SCALING_FACTOR] ? object[keys::SCALING_FACTOR].as<double>() : 1.0;
 
-      std::string name = "PHOTO." + object[keys::MUSICA_NAME].as<std::string>();
-      types::UserDefined user_defined = {
-        .scaling_factor = scaling_factor, .reactants = reactants, .products = products, .name = name
+      std::string name = object[keys::MUSICA_NAME].as<std::string>();
+      types::Photolysis user_defined = {
+        .scaling_factor = scaling_factor, .reactants = reactants[0], .products = products, .name = name
       };
-      mechanism.reactions.user_defined.push_back(user_defined);
+      mechanism.reactions.photolysis.push_back(user_defined);
     }
 
     return errors;

--- a/src/v0/photolysis_parser.cpp
+++ b/src/v0/photolysis_parser.cpp
@@ -32,11 +32,14 @@ namespace mechanism_configuration::v0
 
       double scaling_factor = object[keys::SCALING_FACTOR] ? object[keys::SCALING_FACTOR].as<double>() : 1.0;
 
-      std::string name = object[keys::MUSICA_NAME].as<std::string>();
-      types::Photolysis user_defined = {
-        .scaling_factor = scaling_factor, .reactants = reactants[0], .products = products, .name = name
-      };
-      mechanism.reactions.photolysis.push_back(user_defined);
+      if (!reactants.empty())
+      {
+        std::string name = object[keys::MUSICA_NAME].as<std::string>();
+        types::Photolysis user_defined = {
+          .scaling_factor = scaling_factor, .reactants = reactants[0], .products = products, .name = name
+        };
+        mechanism.reactions.photolysis.push_back(user_defined);
+      }
     }
 
     return errors;

--- a/src/v0/user_defined_reaction_parser.cpp
+++ b/src/v0/user_defined_reaction_parser.cpp
@@ -32,7 +32,7 @@ namespace mechanism_configuration::v0
 
       double scaling_factor = object[keys::SCALING_FACTOR] ? object[keys::SCALING_FACTOR].as<double>() : 1.0;
 
-      std::string name = "USER." + object[keys::MUSICA_NAME].as<std::string>();
+      std::string name = object[keys::MUSICA_NAME].as<std::string>();
 
       types::UserDefined user_defined = {
         .scaling_factor = scaling_factor, .reactants = reactants, .products = products, .name = name

--- a/src/v1/parser.cpp
+++ b/src/v1/parser.cpp
@@ -5,13 +5,13 @@
 #include "detail/v1/parser.hpp"
 
 #include "detail/check_schema.hpp"
+#include "detail/error_format.hpp"
 #include "detail/v1/keys.hpp"
 #include "detail/v1/type_parsers.hpp"
 #include "detail/v1/type_schema.hpp"
 #include "detail/v1/utils.hpp"
 
 #include <mechanism_configuration/errors.hpp>
-#include <mechanism_configuration/format_compat.hpp>
 #include <mechanism_configuration/mechanism.hpp>
 
 #include <yaml-cpp/yaml.h>

--- a/src/v1/reactions/arrhenius.cpp
+++ b/src/v1/reactions/arrhenius.cpp
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <mechanism_configuration/errors.hpp>
-#include <mechanism_configuration/format_compat.hpp>
 #include <mechanism_configuration/types.hpp>
 
 #include <detail/check_schema.hpp>
 #include <detail/constants.hpp>
+#include <detail/error_format.hpp>
 #include <detail/v1/reaction_parsers.hpp>
 #include <detail/v1/type_parsers.hpp>
 #include <detail/v1/type_schema.hpp>

--- a/src/v1/reactions/first_order_loss.cpp
+++ b/src/v1/reactions/first_order_loss.cpp
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <mechanism_configuration/errors.hpp>
-#include <mechanism_configuration/format_compat.hpp>
 #include <mechanism_configuration/types.hpp>
 
 #include <detail/check_schema.hpp>
+#include <detail/error_format.hpp>
 #include <detail/v1/reaction_parsers.hpp>
 #include <detail/v1/type_parsers.hpp>
 #include <detail/v1/type_schema.hpp>

--- a/src/v1/reactions/photolysis.cpp
+++ b/src/v1/reactions/photolysis.cpp
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <mechanism_configuration/errors.hpp>
-#include <mechanism_configuration/format_compat.hpp>
 #include <mechanism_configuration/types.hpp>
 
 #include <detail/check_schema.hpp>
+#include <detail/error_format.hpp>
 #include <detail/v1/reaction_parsers.hpp>
 #include <detail/v1/type_parsers.hpp>
 #include <detail/v1/type_schema.hpp>

--- a/src/v1/reactions/surface.cpp
+++ b/src/v1/reactions/surface.cpp
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <mechanism_configuration/errors.hpp>
-#include <mechanism_configuration/format_compat.hpp>
 #include <mechanism_configuration/types.hpp>
 
 #include <detail/check_schema.hpp>
+#include <detail/error_format.hpp>
 #include <detail/v1/reaction_parsers.hpp>
 #include <detail/v1/type_parsers.hpp>
 #include <detail/v1/type_schema.hpp>

--- a/src/v1/reactions/taylor_series.cpp
+++ b/src/v1/reactions/taylor_series.cpp
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <mechanism_configuration/errors.hpp>
-#include <mechanism_configuration/format_compat.hpp>
 #include <mechanism_configuration/types.hpp>
 
 #include <detail/check_schema.hpp>
 #include <detail/constants.hpp>
+#include <detail/error_format.hpp>
 #include <detail/v1/reaction_parsers.hpp>
 #include <detail/v1/type_parsers.hpp>
 #include <detail/v1/type_schema.hpp>

--- a/src/v1/type_schema.cpp
+++ b/src/v1/type_schema.cpp
@@ -5,12 +5,12 @@
 #include "detail/v1/type_schema.hpp"
 
 #include "detail/check_schema.hpp"
+#include "detail/error_format.hpp"
 #include "detail/v1/keys.hpp"
 #include "detail/v1/reaction_parsers.hpp"
 #include "detail/v1/utils.hpp"
 
 #include <mechanism_configuration/errors.hpp>
-#include <mechanism_configuration/format_compat.hpp>
 
 #include <string>
 #include <vector>

--- a/src/validate.cpp
+++ b/src/validate.cpp
@@ -2,8 +2,9 @@
 //                         University of Illinois at Urbana-Champaign
 // SPDX-License-Identifier: Apache-2.0
 
-#include <mechanism_configuration/format_compat.hpp>
 #include <mechanism_configuration/validate.hpp>
+
+#include "detail/error_format.hpp"
 
 #include <optional>
 #include <string>

--- a/test/integration/test_parser.cpp
+++ b/test/integration/test_parser.cpp
@@ -72,7 +72,7 @@ TEST(Parse, ParsesV0DirectoryConfiguration)
     EXPECT_EQ(parsed->version.major, 0);
 }
 
-TEST(Parse, ParsesV1String)
+TEST(Parse, ParsesV1JsonString)
 {
   std::string config = R"(
   {
@@ -116,7 +116,7 @@ TEST(Parse, ParsesV1String)
   }
 }
 
-TEST(Parse, ParsesV11String)
+TEST(Parse, ParsesV11JsonString)
 {
   std::string config = R"(
   {
@@ -145,6 +145,70 @@ TEST(Parse, ParsesV11String)
       }
     ]
   }
+  )";
+  auto parsed = ParseFromString(config);
+  EXPECT_TRUE(parsed);
+  if (parsed){
+    EXPECT_EQ(parsed->version.major, 1);
+    EXPECT_EQ(parsed->species.size(), 1);
+    EXPECT_EQ(parsed->phases.size(), 1);
+    EXPECT_EQ(parsed->reactions.arrhenius.size(), 1);
+  }
+  else {
+    for (const auto& [code, message] : parsed.error())
+      std::cout << message << " " << ErrorCodeToString(code) << std::endl;
+  }
+}
+
+TEST(Parse, ParsesV1YamlString)
+{
+  std::string config = R"(
+version: 1.0.0
+species:
+  - name: H2O
+phases:
+  - name: gas
+    species:
+      - name: H2O
+reactions:
+  - type: ARRHENIUS
+    reactants:
+      - species name: H2O
+    products:
+      - species name: H2O
+    gas phase: gas
+  )";
+  auto parsed = ParseFromString(config);
+  EXPECT_TRUE(parsed);
+  if (parsed){
+    EXPECT_EQ(parsed->version.major, 1);
+    EXPECT_EQ(parsed->species.size(), 1);
+    EXPECT_EQ(parsed->phases.size(), 1);
+    EXPECT_EQ(parsed->reactions.arrhenius.size(), 1);
+  }
+  else {
+    for (const auto& [code, message] : parsed.error())
+      std::cout << message << " " << ErrorCodeToString(code) << std::endl;
+  }
+}
+
+TEST(Parse, ParsesV11YamlString)
+{
+  std::string config = R"(
+version: 1.1.0
+species:
+  - name: H2O
+phases:
+  - name: gas
+    species:
+      - name: H2O
+reactions:
+  - type: ARRHENIUS
+    reactants:
+      - species name: H2O
+    products:
+      - species name: H2O
+    gas phase: gas
   )";
   auto parsed = ParseFromString(config);
   EXPECT_TRUE(parsed);

--- a/test/integration/test_parser.cpp
+++ b/test/integration/test_parser.cpp
@@ -71,3 +71,91 @@ TEST(Parse, ParsesV0DirectoryConfiguration)
   if (parsed)
     EXPECT_EQ(parsed->version.major, 0);
 }
+
+TEST(Parse, ParsesV1String)
+{
+  std::string config = R"(
+  {
+    "version": "1.0.0",
+    "species": [
+      {
+        "name": "H2O",
+      }
+    ],
+    "phases": [
+      {
+        "name": "gas",
+        "species": [ 
+          {
+            "name": "H2O"
+          }
+        ]
+      }
+    ],
+    "reactions": [
+      {
+        type: "ARRHENIUS",
+        "reactants": [ { "species name": "H2O" } ],
+        "products": [ { "species name": "H2O" } ],
+        "gas phase": "gas",
+      }
+    ]
+  }
+  )";
+  auto parsed = ParseFromString(config);
+  EXPECT_TRUE(parsed);
+  if (parsed){
+    EXPECT_EQ(parsed->version.major, 1);
+    EXPECT_EQ(parsed->species.size(), 1);
+    EXPECT_EQ(parsed->phases.size(), 1);
+    EXPECT_EQ(parsed->reactions.arrhenius.size(), 1);
+  }
+  else {
+    for (const auto& [code, message] : parsed.error())
+      std::cout << message << " " << ErrorCodeToString(code) << std::endl;
+  }
+}
+
+TEST(Parse, ParsesV11String)
+{
+  std::string config = R"(
+  {
+    "version": "1.1.0",
+    "species": [
+      {
+        "name": "H2O",
+      }
+    ],
+    "phases": [
+      {
+        "name": "gas",
+        "species": [ 
+          {
+            "name": "H2O"
+          }
+        ]
+      }
+    ],
+    "reactions": [
+      {
+        type: "ARRHENIUS",
+        "reactants": [ { "species name": "H2O" } ],
+        "products": [ { "species name": "H2O" } ],
+        "gas phase": "gas",
+      }
+    ]
+  }
+  )";
+  auto parsed = ParseFromString(config);
+  EXPECT_TRUE(parsed);
+  if (parsed){
+    EXPECT_EQ(parsed->version.major, 1);
+    EXPECT_EQ(parsed->species.size(), 1);
+    EXPECT_EQ(parsed->phases.size(), 1);
+    EXPECT_EQ(parsed->reactions.arrhenius.size(), 1);
+  }
+  else {
+    for (const auto& [code, message] : parsed.error())
+      std::cout << message << " " << ErrorCodeToString(code) << std::endl;
+  }
+}

--- a/test/integration/test_v0_parser.cpp
+++ b/test/integration/test_v0_parser.cpp
@@ -20,7 +20,10 @@ TEST(V0Parser, ParsesFullV0Configuration)
     ASSERT_TRUE(parsed);
 
     Mechanism mechanism = *parsed;
-    EXPECT_EQ(mechanism.reactions.user_defined.size(), 4);
+    EXPECT_EQ(mechanism.reactions.user_defined.size(), 1);
+    EXPECT_EQ(mechanism.reactions.first_order_loss.size(), 1);
+    EXPECT_EQ(mechanism.reactions.emission.size(), 1);
+    EXPECT_EQ(mechanism.reactions.photolysis.size(), 1);
     EXPECT_EQ(mechanism.reactions.arrhenius.size(), 1);
     EXPECT_EQ(mechanism.reactions.troe.size(), 1);
     EXPECT_EQ(mechanism.reactions.ternary_chemical_activation.size(), 1);
@@ -40,7 +43,10 @@ TEST(V0Parser, ConfigPathIsDirectory)
 
   Mechanism mechanism = *parsed;
   EXPECT_EQ(mechanism.version.major, 0);
-  EXPECT_EQ(mechanism.reactions.user_defined.size(), 4);
+  EXPECT_EQ(mechanism.reactions.user_defined.size(), 1);
+  EXPECT_EQ(mechanism.reactions.first_order_loss.size(), 1);
+  EXPECT_EQ(mechanism.reactions.emission.size(), 1);
+  EXPECT_EQ(mechanism.reactions.photolysis.size(), 1);
   EXPECT_EQ(mechanism.reactions.arrhenius.size(), 1);
   EXPECT_EQ(mechanism.reactions.troe.size(), 1);
   EXPECT_EQ(mechanism.reactions.ternary_chemical_activation.size(), 1);

--- a/test/unit/v0/test_emission_config.cpp
+++ b/test/unit/v0/test_emission_config.cpp
@@ -49,7 +49,7 @@ TEST(EmissionConfig, ParseConfig)
     EXPECT_TRUE(parsed);
     Mechanism mechanism = *parsed;
 
-    auto& process_vector = mechanism.reactions.user_defined;
+    auto& process_vector = mechanism.reactions.emission;
     EXPECT_EQ(process_vector.size(), 2);
 
     // first reaction

--- a/test/unit/v0/test_emission_config.cpp
+++ b/test/unit/v0/test_emission_config.cpp
@@ -54,21 +54,19 @@ TEST(EmissionConfig, ParseConfig)
 
     // first reaction
     {
-      EXPECT_EQ(process_vector[0].reactants.size(), 0);
       EXPECT_EQ(process_vector[0].products.size(), 1);
       EXPECT_EQ(process_vector[0].products[0].name, "foo");
       EXPECT_EQ(process_vector[0].products[0].coefficient, 1.0);
-      EXPECT_EQ(process_vector[0].name, "EMIS.foo");
+      EXPECT_EQ(process_vector[0].name, "foo");
       EXPECT_EQ(process_vector[0].scaling_factor, 1.0);
     }
 
     // second reaction
     {
-      EXPECT_EQ(process_vector[1].reactants.size(), 0);
       EXPECT_EQ(process_vector[1].products.size(), 1);
       EXPECT_EQ(process_vector[1].products[0].name, "bar");
       EXPECT_EQ(process_vector[1].products[0].coefficient, 1.0);
-      EXPECT_EQ(process_vector[1].name, "EMIS.bar");
+      EXPECT_EQ(process_vector[1].name, "bar");
       EXPECT_EQ(process_vector[1].scaling_factor, 2.5);
     }
   }

--- a/test/unit/v0/test_first_order_loss_config.cpp
+++ b/test/unit/v0/test_first_order_loss_config.cpp
@@ -49,24 +49,22 @@ TEST(FirstOrderLossConfig, ParseConfig)
     EXPECT_TRUE(parsed);
     Mechanism mechanism = *parsed;
 
-    auto& process_vector = mechanism.reactions.user_defined;
+    auto& process_vector = mechanism.reactions.first_order_loss;
     EXPECT_EQ(process_vector.size(), 2);
 
     // first reaction
     {
-      EXPECT_EQ(process_vector[0].reactants.size(), 1);
       EXPECT_EQ(process_vector[0].products.size(), 0);
-      EXPECT_EQ(process_vector[0].reactants[0].name, "foo");
-      EXPECT_EQ(process_vector[0].name, "LOSS.foo");
+      EXPECT_EQ(process_vector[0].reactants.name, "foo");
+      EXPECT_EQ(process_vector[0].name, "foo");
       EXPECT_EQ(process_vector[0].scaling_factor, 1.0);
     }
 
     // second reaction
     {
-      EXPECT_EQ(process_vector[1].reactants.size(), 1);
       EXPECT_EQ(process_vector[1].products.size(), 0);
-      EXPECT_EQ(process_vector[1].reactants[0].name, "bar");
-      EXPECT_EQ(process_vector[1].name, "LOSS.bar");
+      EXPECT_EQ(process_vector[1].reactants.name, "bar");
+      EXPECT_EQ(process_vector[1].name, "bar");
       EXPECT_EQ(process_vector[1].scaling_factor, 2.5);
     }
   }

--- a/test/unit/v0/test_photolysis_config.cpp
+++ b/test/unit/v0/test_photolysis_config.cpp
@@ -59,32 +59,30 @@ TEST(PhotolysisConfig, ParseConfig)
     EXPECT_TRUE(parsed);
     Mechanism mechanism = *parsed;
 
-    auto& process_vector = mechanism.reactions.user_defined;
+    auto& process_vector = mechanism.reactions.photolysis;
     EXPECT_EQ(process_vector.size(), 2);
 
     // first reaction
     {
-      EXPECT_EQ(process_vector[0].reactants.size(), 1);
-      EXPECT_EQ(process_vector[0].reactants[0].name, "foo");
+      EXPECT_EQ(process_vector[0].reactants.name, "foo");
       EXPECT_EQ(process_vector[0].products.size(), 2);
       EXPECT_EQ(process_vector[0].products[0].name, "bar");
       EXPECT_EQ(process_vector[0].products[0].coefficient, 1.0);
       EXPECT_EQ(process_vector[0].products[1].name, "baz");
       EXPECT_EQ(process_vector[0].products[1].coefficient, 3.2);
-      EXPECT_EQ(process_vector[0].name, "PHOTO.jfoo");
+      EXPECT_EQ(process_vector[0].name, "jfoo");
       EXPECT_EQ(process_vector[0].scaling_factor, 1.0);
     }
 
     // second reaction
     {
-      EXPECT_EQ(process_vector[1].reactants.size(), 1);
-      EXPECT_EQ(process_vector[1].reactants[0].name, "bar");
+      EXPECT_EQ(process_vector[1].reactants.name, "bar");
       EXPECT_EQ(process_vector[1].products.size(), 2);
       EXPECT_EQ(process_vector[1].products[0].name, "bar");
       EXPECT_EQ(process_vector[1].products[0].coefficient, 0.5);
       EXPECT_EQ(process_vector[1].products[1].name, "foo");
       EXPECT_EQ(process_vector[1].products[1].coefficient, 1.0);
-      EXPECT_EQ(process_vector[1].name, "PHOTO.jbar");
+      EXPECT_EQ(process_vector[1].name, "jbar");
       EXPECT_EQ(process_vector[1].scaling_factor, 2.5);
     }
   }

--- a/test/unit/v0/test_user_defined_config.cpp
+++ b/test/unit/v0/test_user_defined_config.cpp
@@ -76,7 +76,7 @@ TEST(UserDefinedConfig, ParseConfig)
       EXPECT_EQ(process_vector[0].products[0].coefficient, 1.4);
       EXPECT_EQ(process_vector[0].products[1].name, "foo");
       EXPECT_EQ(process_vector[0].products[1].coefficient, 1.0);
-      EXPECT_EQ(process_vector[0].name, "USER.foo");
+      EXPECT_EQ(process_vector[0].name, "foo");
       EXPECT_EQ(process_vector[0].scaling_factor, 1.0);
     }
 
@@ -88,7 +88,7 @@ TEST(UserDefinedConfig, ParseConfig)
       EXPECT_EQ(process_vector[1].products.size(), 1);
       EXPECT_EQ(process_vector[1].products[0].name, "bar");
       EXPECT_EQ(process_vector[1].products[0].coefficient, 1.0);
-      EXPECT_EQ(process_vector[1].name, "USER.bar");
+      EXPECT_EQ(process_vector[1].name, "bar");
       EXPECT_EQ(process_vector[1].scaling_factor, 2.5);
     }
   }


### PR DESCRIPTION
musica needs to be able to parse string content. When I moved the v1 parser from public to private headers, I removed that capability. This adds it back

- make fmt a private implementation header in detail
- make v0 translate each reaction type to it's corresponding reaction type and not translating to user defined (where applicable), not adding `PHOTO.`, `LOSS.`, `USER.`, `EMIS.`