### PR TITLE
Add inline to version print helpers to avoid duplicate errors in downstream

### DIFF
--- a/include/mechanism_configuration/version.hpp
+++ b/include/mechanism_configuration/version.hpp
@@ -11,23 +11,23 @@ namespace mechanism_configuration
 extern "C" {
 #endif
 
-  const char* getVersionString()
+  inline const char* getVersionString()
   {
     return "2.0.0";
   }
-  unsigned getVersionMajor()
+  inline unsigned getVersionMajor()
   {
     return 2;
   }
-  unsigned getVersionMinor()
+  inline unsigned getVersionMinor()
   {
     return 0+0;
   }
-  unsigned getVersionPatch()
+  inline unsigned getVersionPatch()
   {
     return 0+0;
   }
-  unsigned getVersionTweak()
+  inline unsigned getVersionTweak()
   {
     return +0;
   }

--- a/src/version.hpp.in
+++ b/src/version.hpp.in
@@ -11,23 +11,23 @@ namespace mechanism_configuration
 extern "C" {
 #endif
 
-  const char* getVersionString()
+  inline const char* getVersionString()
   {
     return "@mechanism_configuration_VERSION@";
   }
-  unsigned getVersionMajor()
+  inline unsigned getVersionMajor()
   {
     return @mechanism_configuration_VERSION_MAJOR@;
   }
-  unsigned getVersionMinor()
+  inline unsigned getVersionMinor()
   {
     return @mechanism_configuration_VERSION_MINOR@+0;
   }
-  unsigned getVersionPatch()
+  inline unsigned getVersionPatch()
   {
     return @mechanism_configuration_VERSION_PATCH@+0;
   }
-  unsigned getVersionTweak()
+  inline unsigned getVersionTweak()
   {
     return @mechanism_configuration_VERSION_TWEAK@+0;
   }


### PR DESCRIPTION
Add inline to version print helpers to avoid colisions