### PR TITLE
Add ozone oxidation pathway in cloud chemistry configuration

### DIFF
--- a/examples/v1/cam_cloud_chemistry.json
+++ b/examples/v1/cam_cloud_chemistry.json
@@ -130,6 +130,41 @@
       }
     },
     {
+      "__comment": "R2: HSO3- + O3_aq -> SO4-- + H+ (irreversible)",
+      "__note": "k = c_H2O_M * 3.75e5 = 2.08335e7; Ea/R = 5530 K",
+      "type": "DISSOLVED_REACTION",
+      "condensed phase": "AQUEOUS",
+      "solvent": "H2O",
+      "reactants": [
+        { "name": "HSO3m", "coefficient": 1 },
+        { "name": "O3",    "coefficient": 1 }
+      ],
+      "products": [
+        { "name": "SO4mm", "coefficient": 1 },
+        { "name": "Hp",    "coefficient": 1 }
+      ],
+      "rate constants": {
+        "type": "ARRHENIUS", "A": 2.08335e7, "C": 5530.0
+      }
+    },
+    {
+      "__comment": "R3: SO3-- + O3_aq -> SO4-- (irreversible)",
+      "__note": "k = c_H2O_M * 1.59e9 = 8.8334e10; Ea/R = 5280 K",
+      "type": "DISSOLVED_REACTION",
+      "condensed phase": "AQUEOUS",
+      "solvent": "H2O",
+      "reactants": [
+        { "name": "SO3mm", "coefficient": 1 },
+        { "name": "O3",    "coefficient": 1 }
+      ],
+      "products": [
+        { "name": "SO4mm", "coefficient": 1 }
+      ],
+      "rate constants": {
+        "type": "ARRHENIUS", "A": 8.8334e10, "C": 5280.0
+      }
+    },
+    {
       "__comment": "Kw: 2 H2O <-> H+ + OH-",
       "type": "DISSOLVED_EQUILIBRIUM",
       "condensed phase": "AQUEOUS",
@@ -181,7 +216,7 @@
       }
     },
     {
-      "__comment": "Mass conservation: total sulfur in reversible pool (includes SO2OOH-)",
+      "__comment": "Mass conservation: total sulfur in reversible pool (includes SO2OOH-, SO4--)",
       "type": "LINEAR_CONSTRAINT",
       "algebraic phase": "gas",
       "algebraic species": "SO2",
@@ -191,7 +226,8 @@
         { "phase": "AQUEOUS", "name": "SO2",      "coefficient": 1.0 },
         { "phase": "AQUEOUS", "name": "HSO3m",    "coefficient": 1.0 },
         { "phase": "AQUEOUS", "name": "SO3mm",    "coefficient": 1.0 },
-        { "phase": "AQUEOUS", "name": "SO2OOHm",  "coefficient": 1.0 }
+        { "phase": "AQUEOUS", "name": "SO2OOHm",  "coefficient": 1.0 },
+        { "phase": "AQUEOUS", "name": "SO4mm",    "coefficient": 1.0 }
       ]
     },
     {

--- a/test/integration/test_parser.cpp
+++ b/test/integration/test_parser.cpp
@@ -95,13 +95,25 @@ TEST(Parse, ParsesCamCloudChemistryAerosolConfiguration)
   const auto& cloud = std::get<types::UniformSection>(mechanism.aerosol->representations[0]);
   EXPECT_EQ(cloud.name, "CLOUD");
 
-  // Processes: one reversible reaction followed by one dissolved reaction.
-  ASSERT_EQ(mechanism.aerosol->processes.size(), 2u);
+  // Processes: one reversible reaction followed by three dissolved reactions.
+  ASSERT_EQ(mechanism.aerosol->processes.size(), 4u);
   const auto& reversible = std::get<types::DissolvedReversibleReaction>(mechanism.aerosol->processes[0]);
   ASSERT_EQ(reversible.reactants.size(), 2u);
   EXPECT_EQ(reversible.reactants[0].name, "HSO3m");  // components keyed on "name"
   ASSERT_TRUE(reversible.equilibrium_constant.has_value());
   EXPECT_DOUBLE_EQ(reversible.equilibrium_constant->A, 1725.0);
+
+  // The ozone pathway: HSO3- + O3 and SO3-- + O3 both produce SO4--.
+  const auto& ozone_hso3 = std::get<types::DissolvedReaction>(mechanism.aerosol->processes[2]);
+  ASSERT_EQ(ozone_hso3.reactants.size(), 2u);
+  EXPECT_EQ(ozone_hso3.reactants[0].name, "HSO3m");
+  EXPECT_EQ(ozone_hso3.reactants[1].name, "O3");
+  const auto& ozone_so3 = std::get<types::DissolvedReaction>(mechanism.aerosol->processes[3]);
+  ASSERT_EQ(ozone_so3.reactants.size(), 2u);
+  EXPECT_EQ(ozone_so3.reactants[0].name, "SO3mm");
+  EXPECT_EQ(ozone_so3.reactants[1].name, "O3");
+  ASSERT_EQ(ozone_so3.products.size(), 1u);
+  EXPECT_EQ(ozone_so3.products[0].name, "SO4mm");
 
   // Constraints: 3 Henry's-law equilibria + 3 dissolved equilibria + 4 linear constraints.
   ASSERT_EQ(mechanism.aerosol->constraints.size(), 10u);


### PR DESCRIPTION
This PR:
- Adds ozone oxidation pathway in cloud chemistry configuration.
- Adds a missing SO4-- to the total sulfur mass conservation constraint.
- Closes #298 