### PR TITLE
Fix rate constant label

### DIFF
--- a/examples/v1/cam_cloud_chemistry.json
+++ b/examples/v1/cam_cloud_chemistry.json
@@ -105,7 +105,7 @@
         { "name": "SO2OOHm", "coefficient": 1 },
         { "name": "H2O",     "coefficient": 1 }
       ],
-      "forward rate constants": {
+      "forward rate constant": {
         "type": "ARRHENIUS", "A": 3.184e8,  "C": 4430.0
       },
       "equilibrium constant": {
@@ -125,7 +125,7 @@
       "products": [
         { "name": "SO4mm", "coefficient": 1 }
       ],
-      "rate constants": {
+      "rate constant": {
         "type": "ARRHENIUS", "A": 1.333e8, "C": 4430.0
       }
     },
@@ -143,7 +143,7 @@
         { "name": "SO4mm", "coefficient": 1 },
         { "name": "Hp",    "coefficient": 1 }
       ],
-      "rate constants": {
+      "rate constant": {
         "type": "ARRHENIUS", "A": 2.08335e7, "C": 5530.0
       }
     },
@@ -160,7 +160,7 @@
       "products": [
         { "name": "SO4mm", "coefficient": 1 }
       ],
-      "rate constants": {
+      "rate constant": {
         "type": "ARRHENIUS", "A": 8.8334e10, "C": 5280.0
       }
     },

--- a/include/mechanism_configuration/types/aerosol.hpp
+++ b/include/mechanism_configuration/types/aerosol.hpp
@@ -78,7 +78,7 @@ namespace mechanism_configuration::types
     std::string solvent;
     std::vector<ReactionComponent> reactants;
     std::vector<ReactionComponent> products;
-    RateConstant rate_constants;
+    RateConstant rate_constant;
     std::optional<double> solvent_floor_;
     std::optional<double> min_halflife_;
   };
@@ -90,8 +90,8 @@ namespace mechanism_configuration::types
     std::vector<ReactionComponent> reactants;
     std::vector<ReactionComponent> products;
     /// @brief Supply exactly two of {forward, reverse, equilibrium}; the third is derived.
-    std::optional<RateConstant> forward_rate_constants;
-    std::optional<RateConstant> reverse_rate_constants;
+    std::optional<RateConstant> forward_rate_constant;
+    std::optional<RateConstant> reverse_rate_constant;
     /// @brief Shared, intrinsic equilibrium constant (NOT per representation).
     std::optional<Equilibrium> equilibrium_constant;
     std::optional<double> solvent_floor_;

--- a/src/detail/v1/aerosol/keys.hpp
+++ b/src/detail/v1/aerosol/keys.hpp
@@ -33,9 +33,9 @@ namespace mechanism_configuration::v1::keys
   // ----------------------------------------
   // Rate constants
   // ----------------------------------------
-  inline constexpr std::string_view rate_constants = "rate constants";
-  inline constexpr std::string_view forward_rate_constants = "forward rate constants";
-  inline constexpr std::string_view reverse_rate_constants = "reverse rate constants";
+  inline constexpr std::string_view rate_constant = "rate constant";
+  inline constexpr std::string_view forward_rate_constant = "forward rate constant";
+  inline constexpr std::string_view reverse_rate_constant = "reverse rate constant";
   inline constexpr std::string_view equilibrium_constant = "equilibrium constant";
   inline constexpr std::string_view reference_temperature = "T0 [K]";
 
@@ -58,12 +58,12 @@ namespace mechanism_configuration::v1::keys
   inline constexpr std::string_view accommodation_coefficient = "accommodation coefficient";
 
   // DissolvedReaction
-  // also: condensed_phase, solvent, reactants, products, rate_constants
+  // also: condensed_phase, solvent, reactants, products, rate_constant
   inline constexpr std::string_view DissolvedReaction_key = "DISSOLVED_REACTION";
 
   // DissolvedReversibleReaction
   // also: condensed_phase, solvent, reactants, products,
-  //       forward_rate_constants, reverse_rate_constants, equilibrium_constant
+  //       forward_rate_constant, reverse_rate_constant, equilibrium_constant
   inline constexpr std::string_view DissolvedReversibleReaction_key = "DISSOLVED_REVERSIBLE_REACTION";
 
   // ----------------------------------------

--- a/src/v1/aerosol/parsers.cpp
+++ b/src/v1/aerosol/parsers.cpp
@@ -148,7 +148,7 @@ namespace mechanism_configuration::v1
     reaction.solvent = object[keys::solvent].as<std::string>();
     reaction.reactants = ParseReactionComponents(object, keys::reactants);
     reaction.products = ParseReactionComponents(object, keys::products);
-    reaction.rate_constants = ParseRateConstant(object[keys::rate_constants]);
+    reaction.rate_constant = ParseRateConstant(object[keys::rate_constant]);
 
     return reaction;
   }
@@ -164,10 +164,10 @@ namespace mechanism_configuration::v1
 
     // Any two of {forward, reverse, equilibrium} may be supplied; the third is derived
     // downstream, so each is parsed only when present.
-    if (object[keys::forward_rate_constants])
-      reaction.forward_rate_constants = ParseRateConstant(object[keys::forward_rate_constants]);
-    if (object[keys::reverse_rate_constants])
-      reaction.reverse_rate_constants = ParseRateConstant(object[keys::reverse_rate_constants]);
+    if (object[keys::forward_rate_constant])
+      reaction.forward_rate_constant = ParseRateConstant(object[keys::forward_rate_constant]);
+    if (object[keys::reverse_rate_constant])
+      reaction.reverse_rate_constant = ParseRateConstant(object[keys::reverse_rate_constant]);
     if (object[keys::equilibrium_constant])
       reaction.equilibrium_constant = ParseEquilibrium(object[keys::equilibrium_constant]);
 

--- a/src/v1/aerosol/schema.cpp
+++ b/src/v1/aerosol/schema.cpp
@@ -153,7 +153,7 @@ namespace mechanism_configuration::v1
       else if (type == keys::DissolvedReaction_key)
       {
         required_keys = { keys::type,      keys::condensed_phase, keys::solvent,
-                          keys::reactants, keys::products,        keys::rate_constants };
+                          keys::reactants, keys::products,        keys::rate_constant };
         if (object[keys::reactants])
         {
           auto e = CheckReactantsOrProductsSchema(object[keys::reactants]);
@@ -164,16 +164,16 @@ namespace mechanism_configuration::v1
           auto e = CheckReactantsOrProductsSchema(object[keys::products]);
           nested_errors.insert(nested_errors.end(), e.begin(), e.end());
         }
-        if (object[keys::rate_constants])
+        if (object[keys::rate_constant])
         {
-          auto e = CheckRateConstantSchema(object[keys::rate_constants]);
+          auto e = CheckRateConstantSchema(object[keys::rate_constant]);
           nested_errors.insert(nested_errors.end(), e.begin(), e.end());
         }
       }
       else if (type == keys::DissolvedReversibleReaction_key)
       {
         required_keys = { keys::type, keys::condensed_phase, keys::solvent, keys::reactants, keys::products };
-        optional_keys = { keys::forward_rate_constants, keys::reverse_rate_constants, keys::equilibrium_constant };
+        optional_keys = { keys::forward_rate_constant, keys::reverse_rate_constant, keys::equilibrium_constant };
         if (object[keys::reactants])
         {
           auto e = CheckReactantsOrProductsSchema(object[keys::reactants]);
@@ -184,14 +184,14 @@ namespace mechanism_configuration::v1
           auto e = CheckReactantsOrProductsSchema(object[keys::products]);
           nested_errors.insert(nested_errors.end(), e.begin(), e.end());
         }
-        if (object[keys::forward_rate_constants])
+        if (object[keys::forward_rate_constant])
         {
-          auto e = CheckRateConstantSchema(object[keys::forward_rate_constants]);
+          auto e = CheckRateConstantSchema(object[keys::forward_rate_constant]);
           nested_errors.insert(nested_errors.end(), e.begin(), e.end());
         }
-        if (object[keys::reverse_rate_constants])
+        if (object[keys::reverse_rate_constant])
         {
-          auto e = CheckRateConstantSchema(object[keys::reverse_rate_constants]);
+          auto e = CheckRateConstantSchema(object[keys::reverse_rate_constant]);
           nested_errors.insert(nested_errors.end(), e.begin(), e.end());
         }
         if (object[keys::equilibrium_constant])

--- a/test/unit/test_validate.cpp
+++ b/test/unit/test_validate.cpp
@@ -246,7 +246,7 @@ TEST(ValidateAerosol, AcceptsValidProcessesAndConstraints)
   reaction.solvent = "H2O";
   reaction.reactants = { component("A") };
   reaction.products = { component("A") };
-  reaction.rate_constants = types::Equilibrium{};
+  reaction.rate_constant = types::Equilibrium{};
   m.aerosol->processes.push_back(reaction);
 
   m.aerosol->constraints = { ValidEquilibrium() };

--- a/test/unit/v1/v1_unit_configs/aerosol/valid_aerosol.json
+++ b/test/unit/v1/v1_unit_configs/aerosol/valid_aerosol.json
@@ -55,7 +55,7 @@
       "solvent": "H2O",
       "reactants": [ { "name": "A", "coefficient": 1 } ],
       "products": [ { "name": "B", "coefficient": 1 } ],
-      "rate constants": { "type": "ARRHENIUS", "A": 1.0e3, "C": 100.0 }
+      "rate constant": { "type": "ARRHENIUS", "A": 1.0e3, "C": 100.0 }
     },
     {
       "type": "HENRY_LAW_EQUILIBRIUM",


### PR DESCRIPTION
This PR updates the data members and keys for `DissolvedReaction` and `DissolvedReversibleReaction` to use `rate_constant` instead of `rate_constants`, which is consistent with the revised classes in MUSICA and MIAM