### PR TITLE
Rename to Henry's Law

### DIFF
--- a/examples/v1/cam_cloud_chemistry.json
+++ b/examples/v1/cam_cloud_chemistry.json
@@ -49,7 +49,7 @@
     {
       "__comment": "Henry's Law Equilibrium: SO2(g) <-> SO2(aq)",
       "__note": "HLC = HLC_ref * exp(C*(1/T - 1/T0))",
-      "type": "HENRY_LAW_EQUILIBRIUM",
+      "type": "HENRYS_LAW_EQUILIBRIUM",
       "gas phase": "gas",
       "gas-phase species": "SO2",
       "condensed phase": "AQUEOUS",
@@ -64,7 +64,7 @@
     {
       "__comment": "Henry's Law Equilibrium: H2O2(g) <-> H2O2(aq)",
       "__note": "HLC = HLC_ref * exp(C*(1/T - 1/T0))",
-      "type": "HENRY_LAW_EQUILIBRIUM",
+      "type": "HENRYS_LAW_EQUILIBRIUM",
       "gas phase": "gas",
       "gas-phase species": "H2O2",
       "condensed phase": "AQUEOUS",
@@ -79,7 +79,7 @@
     {
       "__comment": "Henry's Law Equilibrium: O3(g) <-> O3(aq)",
       "__note": "HLC = HLC_ref * exp(C*(1/T - 1/T0))",
-      "type": "HENRY_LAW_EQUILIBRIUM",
+      "type": "HENRYS_LAW_EQUILIBRIUM",
       "gas phase": "gas",
       "gas-phase species": "O3",
       "condensed phase": "AQUEOUS",

--- a/include/mechanism_configuration/types/aerosol.hpp
+++ b/include/mechanism_configuration/types/aerosol.hpp
@@ -29,7 +29,7 @@ namespace mechanism_configuration::types
 
   /// @brief Henry's law constant: HLC(T) = HLC_ref * exp( C * (1/T - 1/T0) )
   ///        Same as Equilibrium but with the opposite temperature trend
-  struct HenryLawConstant
+  struct HenrysLawConstant
   {
     double HLC_ref;      ///< Reference HLC at T0 [mol m-3 Pa-1]
     double C = 0.0;      ///< Temperature-dependence parameter [K]
@@ -97,32 +97,32 @@ namespace mechanism_configuration::types
     std::optional<double> solvent_floor_;
   };
 
-  struct HenryLawPhaseTransfer
+  struct HenrysLawPhaseTransfer
   {
     std::string gas_phase;
     std::string gas_species;
     std::string condensed_phase;
     std::string condensed_species;
     std::string solvent;
-    HenryLawConstant henry_law_constant;
+    HenrysLawConstant henrys_law_constant;
     double diffusion_coefficient;      ///< Gas-phase diffusion coefficient [m2 s-1]
     double accommodation_coefficient;  ///< Mass accommodation coefficient, dimensionless
   };
 
-  using Process = std::variant<DissolvedReaction, DissolvedReversibleReaction, HenryLawPhaseTransfer>;
+  using Process = std::variant<DissolvedReaction, DissolvedReversibleReaction, HenrysLawPhaseTransfer>;
 
   // ----------------------------------------
   // Constraints
   // ----------------------------------------
 
-  struct HenryLawEquilibrium
+  struct HenrysLawEquilibrium
   {
     std::string gas_phase;
     std::string gas_species;
     std::string condensed_phase;
     std::string condensed_species;
     std::string solvent;
-    HenryLawConstant henry_law_constant;
+    HenrysLawConstant henrys_law_constant;
     double solvent_molecular_weight;  ///< [kg mol-1]
     double solvent_density;           ///< [kg m-3]
   };
@@ -163,7 +163,7 @@ namespace mechanism_configuration::types
     std::variant<FixedConstant, DiagnoseFromState> constant = FixedConstant{ 0.0 };
   };
 
-  using Constraint = std::variant<HenryLawEquilibrium, DissolvedEquilibrium, LinearConstraint>;
+  using Constraint = std::variant<HenrysLawEquilibrium, DissolvedEquilibrium, LinearConstraint>;
 
   // ----------------------------------------
   // Container

--- a/src/detail/v1/aerosol/keys.hpp
+++ b/src/detail/v1/aerosol/keys.hpp
@@ -41,9 +41,9 @@ namespace mechanism_configuration::v1::keys
 
   inline constexpr std::string_view Equilibrium_key = "EQUILIBRIUM";
 
-  inline constexpr std::string_view henry_law_constant = "Henry's law constant";
+  inline constexpr std::string_view henrys_law_constant = "Henry's law constant";
   inline constexpr std::string_view HLC_ref = "HLC_ref [mol m-3 Pa-1]";
-  inline constexpr std::string_view henry_law_C = "C [K]";
+  inline constexpr std::string_view henrys_law_C = "C [K]";
 
   // ----------------------------------------
   // Processes
@@ -51,10 +51,10 @@ namespace mechanism_configuration::v1::keys
   inline constexpr std::string_view solvent = "solvent";
   inline constexpr std::string_view condensed_phase_species = "condensed-phase species";
 
-  // HenryLawPhaseTransfer
+  // HenrysLawPhaseTransfer
   // also: gas_phase, gas_phase_species, condensed_phase, condensed_phase_species, solvent,
-  //       henry_law_constant, diffusion_coefficient
-  inline constexpr std::string_view HenryLawPhaseTransfer_key = "HENRY_LAW_PHASE_TRANSFER";
+  //       henrys_law_constant, diffusion_coefficient
+  inline constexpr std::string_view HenrysLawPhaseTransfer_key = "HENRYS_LAW_PHASE_TRANSFER";
   inline constexpr std::string_view accommodation_coefficient = "accommodation coefficient";
 
   // DissolvedReaction
@@ -69,10 +69,10 @@ namespace mechanism_configuration::v1::keys
   // ----------------------------------------
   // Constraints
   // ----------------------------------------
-  // HenryLawEquilibrium
+  // HenrysLawEquilibrium
   // also: gas_phase, gas_phase_species, condensed_phase, condensed_phase_species, solvent,
-  //       henry_law_constant
-  inline constexpr std::string_view HenryLawEquilibrium_key = "HENRY_LAW_EQUILIBRIUM";
+  //       henrys_law_constant
+  inline constexpr std::string_view HenrysLawEquilibrium_key = "HENRYS_LAW_EQUILIBRIUM";
   inline constexpr std::string_view solvent_molecular_weight = "solvent molecular weight [kg mol-1]";
   inline constexpr std::string_view solvent_density = "solvent density [kg m-3]";
 

--- a/src/detail/v1/aerosol/parsers.hpp
+++ b/src/detail/v1/aerosol/parsers.hpp
@@ -19,7 +19,7 @@ namespace mechanism_configuration::v1
   // Rate constant parsers
   // ----------------------------------------
 
-  types::HenryLawConstant ParseHenryLawConstant(const YAML::Node& object);
+  types::HenrysLawConstant ParseHenrysLawConstant(const YAML::Node& object);
   types::Equilibrium ParseEquilibrium(const YAML::Node& object);
 
   /// @brief Parses a bare Arrhenius rate-constant block (A, B, C, D, E).
@@ -43,7 +43,7 @@ namespace mechanism_configuration::v1
 
   /// @brief Parses a Henry's-law phase transfer. The diffusion coefficient is sourced from the
   ///        gas-phase species' definition in `phases`.
-  types::HenryLawPhaseTransfer ParseHenryLawPhaseTransfer(const YAML::Node& object, const std::vector<types::Phase>& phases);
+  types::HenrysLawPhaseTransfer ParseHenrysLawPhaseTransfer(const YAML::Node& object, const std::vector<types::Phase>& phases);
   types::DissolvedReaction ParseDissolvedReaction(const YAML::Node& object);
   types::DissolvedReversibleReaction ParseDissolvedReversibleReaction(const YAML::Node& object);
 
@@ -53,7 +53,7 @@ namespace mechanism_configuration::v1
 
   /// @brief Parses a Henry's-law equilibrium. The solvent's molecular weight is sourced from the
   ///        species section and its density from the condensed phase.
-  types::HenryLawEquilibrium ParseHenryLawEquilibrium(
+  types::HenrysLawEquilibrium ParseHenrysLawEquilibrium(
       const YAML::Node& object,
       const std::vector<types::Species>& species,
       const std::vector<types::Phase>& phases);

--- a/src/v1/aerosol/parsers.cpp
+++ b/src/v1/aerosol/parsers.cpp
@@ -20,8 +20,8 @@ namespace mechanism_configuration::v1
     types::Equilibrium rate_constant;
 
     rate_constant.A = object[keys::A].as<double>();
-    if (object[keys::henry_law_C])
-      rate_constant.C = object[keys::henry_law_C].as<double>();
+    if (object[keys::henrys_law_C])
+      rate_constant.C = object[keys::henrys_law_C].as<double>();
     if (object[keys::reference_temperature])
       rate_constant.T0 = object[keys::reference_temperature].as<double>();
 
@@ -54,17 +54,17 @@ namespace mechanism_configuration::v1
     return ParseArrhenius(object);
   }
 
-  types::HenryLawConstant ParseHenryLawConstant(const YAML::Node& object)
+  types::HenrysLawConstant ParseHenrysLawConstant(const YAML::Node& object)
   {
-    types::HenryLawConstant henry_law_constant;
+    types::HenrysLawConstant henrys_law_constant;
 
-    henry_law_constant.HLC_ref = object[keys::HLC_ref].as<double>();
-    if (object[keys::henry_law_C])
-      henry_law_constant.C = object[keys::henry_law_C].as<double>();
+    henrys_law_constant.HLC_ref = object[keys::HLC_ref].as<double>();
+    if (object[keys::henrys_law_C])
+      henrys_law_constant.C = object[keys::henrys_law_C].as<double>();
     if (object[keys::reference_temperature])
-      henry_law_constant.T0 = object[keys::reference_temperature].as<double>();
+      henrys_law_constant.T0 = object[keys::reference_temperature].as<double>();
 
-    return henry_law_constant;
+    return henrys_law_constant;
   }
 
   // ----------------------------------------
@@ -121,16 +121,16 @@ namespace mechanism_configuration::v1
   // Process parsers
   // ----------------------------------------
 
-  types::HenryLawPhaseTransfer ParseHenryLawPhaseTransfer(const YAML::Node& object, const std::vector<types::Phase>& phases)
+  types::HenrysLawPhaseTransfer ParseHenrysLawPhaseTransfer(const YAML::Node& object, const std::vector<types::Phase>& phases)
   {
-    types::HenryLawPhaseTransfer transfer;
+    types::HenrysLawPhaseTransfer transfer;
 
     transfer.gas_phase = object[keys::gas_phase].as<std::string>();
     transfer.gas_species = object[keys::gas_phase_species].as<std::string>();
     transfer.condensed_phase = object[keys::condensed_phase].as<std::string>();
     transfer.condensed_species = object[keys::condensed_phase_species].as<std::string>();
     transfer.solvent = object[keys::solvent].as<std::string>();
-    transfer.henry_law_constant = ParseHenryLawConstant(object[keys::henry_law_constant]);
+    transfer.henrys_law_constant = ParseHenrysLawConstant(object[keys::henrys_law_constant]);
     // Sourced from the gas-phase species' definition; presence is enforced by ValidateAerosolModel,
     // which runs before this result is returned, so a missing value defaults harmlessly here.
     transfer.diffusion_coefficient =
@@ -178,19 +178,19 @@ namespace mechanism_configuration::v1
   // Constraint parsers
   // ----------------------------------------
 
-  types::HenryLawEquilibrium ParseHenryLawEquilibrium(
+  types::HenrysLawEquilibrium ParseHenrysLawEquilibrium(
       const YAML::Node& object,
       const std::vector<types::Species>& species,
       const std::vector<types::Phase>& phases)
   {
-    types::HenryLawEquilibrium equilibrium;
+    types::HenrysLawEquilibrium equilibrium;
 
     equilibrium.gas_phase = object[keys::gas_phase].as<std::string>();
     equilibrium.gas_species = object[keys::gas_phase_species].as<std::string>();
     equilibrium.condensed_phase = object[keys::condensed_phase].as<std::string>();
     equilibrium.condensed_species = object[keys::condensed_phase_species].as<std::string>();
     equilibrium.solvent = object[keys::solvent].as<std::string>();
-    equilibrium.henry_law_constant = ParseHenryLawConstant(object[keys::henry_law_constant]);
+    equilibrium.henrys_law_constant = ParseHenrysLawConstant(object[keys::henrys_law_constant]);
 
     // Sourced from the solvent species' definition: molecular weight from the species section,
     // density from the condensed phase. Presence is enforced by ValidateAerosolModel, which runs
@@ -280,15 +280,15 @@ namespace mechanism_configuration::v1
         const auto type = entry[keys::type].as<std::string>();
 
         // Processes
-        if (type == keys::HenryLawPhaseTransfer_key)
-          aerosol.processes.emplace_back(ParseHenryLawPhaseTransfer(entry, phases));
+        if (type == keys::HenrysLawPhaseTransfer_key)
+          aerosol.processes.emplace_back(ParseHenrysLawPhaseTransfer(entry, phases));
         else if (type == keys::DissolvedReaction_key)
           aerosol.processes.emplace_back(ParseDissolvedReaction(entry));
         else if (type == keys::DissolvedReversibleReaction_key)
           aerosol.processes.emplace_back(ParseDissolvedReversibleReaction(entry));
         // Constraints
-        else if (type == keys::HenryLawEquilibrium_key)
-          aerosol.constraints.emplace_back(ParseHenryLawEquilibrium(entry, species, phases));
+        else if (type == keys::HenrysLawEquilibrium_key)
+          aerosol.constraints.emplace_back(ParseHenrysLawEquilibrium(entry, species, phases));
         else if (type == keys::DissolvedEquilibrium_key)
           aerosol.constraints.emplace_back(ParseDissolvedEquilibrium(entry));
         else if (type == keys::LinearConstraint_key)

--- a/src/v1/aerosol/schema.cpp
+++ b/src/v1/aerosol/schema.cpp
@@ -23,7 +23,7 @@ namespace mechanism_configuration::v1
   {
     Errors CheckEquilibriumSchema(const YAML::Node& object)
     {
-      const std::vector<std::string_view> required_keys = { keys::A, keys::henry_law_C };
+      const std::vector<std::string_view> required_keys = { keys::A, keys::henrys_law_C };
       const std::vector<std::string_view> optional_keys = { keys::type, keys::reference_temperature };
       return CheckSchema(object, required_keys, optional_keys);
     }
@@ -42,9 +42,9 @@ namespace mechanism_configuration::v1
       return CheckArrheniusSchema(object);
     }
 
-    Errors CheckHenryLawConstantSchema(const YAML::Node& object)
+    Errors CheckHenrysLawConstantSchema(const YAML::Node& object)
     {
-      const std::vector<std::string_view> required_keys = { keys::HLC_ref, keys::henry_law_C };
+      const std::vector<std::string_view> required_keys = { keys::HLC_ref, keys::henrys_law_C };
       const std::vector<std::string_view> optional_keys = { keys::reference_temperature };
       return CheckSchema(object, required_keys, optional_keys);
     }
@@ -135,7 +135,7 @@ namespace mechanism_configuration::v1
       Errors nested_errors;
 
       const std::string type = object[keys::type].as<std::string>();
-      if (type == keys::HenryLawPhaseTransfer_key)
+      if (type == keys::HenrysLawPhaseTransfer_key)
       {
         // The diffusion coefficient is not given here. It is sourced from the gas-phase
         // species' definition in the phases section (see ValidateAerosolModel).
@@ -145,10 +145,10 @@ namespace mechanism_configuration::v1
                           keys::condensed_phase,
                           keys::condensed_phase_species,
                           keys::solvent,
-                          keys::henry_law_constant,
+                          keys::henrys_law_constant,
                           keys::accommodation_coefficient };
-        if (object[keys::henry_law_constant])
-          nested_errors = CheckHenryLawConstantSchema(object[keys::henry_law_constant]);
+        if (object[keys::henrys_law_constant])
+          nested_errors = CheckHenrysLawConstantSchema(object[keys::henrys_law_constant]);
       }
       else if (type == keys::DissolvedReaction_key)
       {
@@ -200,7 +200,7 @@ namespace mechanism_configuration::v1
           nested_errors.insert(nested_errors.end(), e.begin(), e.end());
         }
       }
-      else if (type == keys::HenryLawEquilibrium_key)
+      else if (type == keys::HenrysLawEquilibrium_key)
       {
         // The solvent's molecular weight and density are not given here; they are sourced from
         // the solvent species' definition (see ValidateAerosolModel).
@@ -210,9 +210,9 @@ namespace mechanism_configuration::v1
                           keys::condensed_phase,
                           keys::condensed_phase_species,
                           keys::solvent,
-                          keys::henry_law_constant };
-        if (object[keys::henry_law_constant])
-          nested_errors = CheckHenryLawConstantSchema(object[keys::henry_law_constant]);
+                          keys::henrys_law_constant };
+        if (object[keys::henrys_law_constant])
+          nested_errors = CheckHenrysLawConstantSchema(object[keys::henrys_law_constant]);
       }
       else if (type == keys::DissolvedEquilibrium_key)
       {

--- a/src/validate.cpp
+++ b/src/validate.cpp
@@ -403,22 +403,22 @@ namespace mechanism_configuration
           require_registered_species(p->phase, c.name, "DISSOLVED_REVERSIBLE_REACTION product");
         require_registered_species(p->phase, p->solvent, "DISSOLVED_REVERSIBLE_REACTION solvent");
       }
-      else if (const auto* p = std::get_if<types::HenryLawPhaseTransfer>(&process))
+      else if (const auto* p = std::get_if<types::HenrysLawPhaseTransfer>(&process))
       {
-        require_registered_species(p->condensed_phase, p->condensed_species, "HENRY_LAW_PHASE_TRANSFER condensed species");
-        require_registered_species(p->condensed_phase, p->solvent, "HENRY_LAW_PHASE_TRANSFER solvent");
-        require_diffusion(p->gas_phase, p->gas_species, "HENRY_LAW_PHASE_TRANSFER");
+        require_registered_species(p->condensed_phase, p->condensed_species, "HENRYS_LAW_PHASE_TRANSFER condensed species");
+        require_registered_species(p->condensed_phase, p->solvent, "HENRYS_LAW_PHASE_TRANSFER solvent");
+        require_diffusion(p->gas_phase, p->gas_species, "HENRYS_LAW_PHASE_TRANSFER");
       }
     }
 
     for (const auto& constraint : aerosol.constraints)
     {
-      if (const auto* c = std::get_if<types::HenryLawEquilibrium>(&constraint))
+      if (const auto* c = std::get_if<types::HenrysLawEquilibrium>(&constraint))
       {
-        require_registered_species(c->gas_phase, c->gas_species, "HENRY_LAW_EQUILIBRIUM gas species");
-        require_registered_species(c->condensed_phase, c->condensed_species, "HENRY_LAW_EQUILIBRIUM condensed species");
-        require_density(c->condensed_phase, c->solvent, "HENRY_LAW_EQUILIBRIUM solvent");
-        require_molecular_weight(c->solvent, "HENRY_LAW_EQUILIBRIUM solvent");
+        require_registered_species(c->gas_phase, c->gas_species, "HENRYS_LAW_EQUILIBRIUM gas species");
+        require_registered_species(c->condensed_phase, c->condensed_species, "HENRYS_LAW_EQUILIBRIUM condensed species");
+        require_density(c->condensed_phase, c->solvent, "HENRYS_LAW_EQUILIBRIUM solvent");
+        require_molecular_weight(c->solvent, "HENRYS_LAW_EQUILIBRIUM solvent");
       }
       else if (const auto* c = std::get_if<types::DissolvedEquilibrium>(&constraint))
       {

--- a/test/integration/test_parser.cpp
+++ b/test/integration/test_parser.cpp
@@ -120,7 +120,7 @@ TEST(Parse, ParsesCamCloudChemistryAerosolConfiguration)
 
   // The first constraint is the SO2 Henry's-law equilibrium; its solvent properties are sourced
   // from the species/phase definitions rather than the process block.
-  const auto& so2_equilibrium = std::get<types::HenryLawEquilibrium>(mechanism.aerosol->constraints[0]);
+  const auto& so2_equilibrium = std::get<types::HenrysLawEquilibrium>(mechanism.aerosol->constraints[0]);
   EXPECT_EQ(so2_equilibrium.solvent, "H2O");
   EXPECT_DOUBLE_EQ(so2_equilibrium.solvent_molecular_weight, 0.01801);  // from the species section
   EXPECT_DOUBLE_EQ(so2_equilibrium.solvent_density, 997.0);             // from the AQUEOUS phase

--- a/test/unit/test_validate.cpp
+++ b/test/unit/test_validate.cpp
@@ -208,9 +208,9 @@ namespace
     return m;
   }
 
-  types::HenryLawPhaseTransfer ValidPhaseTransfer()
+  types::HenrysLawPhaseTransfer ValidPhaseTransfer()
   {
-    types::HenryLawPhaseTransfer t;
+    types::HenrysLawPhaseTransfer t;
     t.gas_phase = "gas";
     t.gas_species = "A";
     t.condensed_phase = "aqueous";
@@ -219,9 +219,9 @@ namespace
     return t;
   }
 
-  types::HenryLawEquilibrium ValidEquilibrium()
+  types::HenrysLawEquilibrium ValidEquilibrium()
   {
-    types::HenryLawEquilibrium e;
+    types::HenrysLawEquilibrium e;
     e.gas_phase = "gas";
     e.gas_species = "A";
     e.condensed_phase = "aqueous";

--- a/test/unit/v1/test_parse_aerosol.cpp
+++ b/test/unit/v1/test_parse_aerosol.cpp
@@ -54,7 +54,7 @@ TEST(ParseAerosol, ParsesValidAerosolConfiguration)
   ASSERT_EQ(aerosol.processes.size(), 2u);
 
   // The phase transfer's diffusion coefficient is sourced from the gas-phase species definition.
-  const auto& transfer = std::get<types::HenryLawPhaseTransfer>(aerosol.processes[0]);
+  const auto& transfer = std::get<types::HenrysLawPhaseTransfer>(aerosol.processes[0]);
   EXPECT_DOUBLE_EQ(transfer.diffusion_coefficient, 1.5e-5);
   EXPECT_DOUBLE_EQ(transfer.accommodation_coefficient, 0.1);
 
@@ -69,7 +69,7 @@ TEST(ParseAerosol, ParsesValidAerosolConfiguration)
   ASSERT_EQ(aerosol.constraints.size(), 2u);
 
   // The solvent properties are sourced from the species/phase definitions.
-  const auto& equilibrium = std::get<types::HenryLawEquilibrium>(aerosol.constraints[0]);
+  const auto& equilibrium = std::get<types::HenrysLawEquilibrium>(aerosol.constraints[0]);
   EXPECT_EQ(equilibrium.solvent, "H2O");
   EXPECT_DOUBLE_EQ(equilibrium.solvent_molecular_weight, 0.018);  // from the species section
   EXPECT_DOUBLE_EQ(equilibrium.solvent_density, 1000.0);          // from the aqueous phase
@@ -89,7 +89,7 @@ TEST(ParseAerosol, RejectsPhaseTransferWhenGasSpeciesHasNoDiffusionCoefficient)
   EXPECT_TRUE(HasError(parsed.error(), ErrorCode::RequiredKeyNotFound));
 }
 
-TEST(ParseAerosol, RejectsHenryLawEquilibriumWhenSolventHasNoDensity)
+TEST(ParseAerosol, RejectsHenrysLawEquilibriumWhenSolventHasNoDensity)
 {
   auto parsed = Parse("v1_unit_configs/aerosol/equilibrium_missing_solvent_density.json");
   EXPECT_FALSE(parsed);

--- a/test/unit/v1/v1_unit_configs/aerosol/equilibrium_missing_solvent_density.json
+++ b/test/unit/v1/v1_unit_configs/aerosol/equilibrium_missing_solvent_density.json
@@ -23,7 +23,7 @@
   ],
   "aerosol processes": [
     {
-      "type": "HENRY_LAW_EQUILIBRIUM",
+      "type": "HENRYS_LAW_EQUILIBRIUM",
       "gas phase": "gas",
       "gas-phase species": "A",
       "condensed phase": "aqueous",

--- a/test/unit/v1/v1_unit_configs/aerosol/phase_transfer_missing_diffusion.json
+++ b/test/unit/v1/v1_unit_configs/aerosol/phase_transfer_missing_diffusion.json
@@ -23,7 +23,7 @@
   ],
   "aerosol processes": [
     {
-      "type": "HENRY_LAW_PHASE_TRANSFER",
+      "type": "HENRYS_LAW_PHASE_TRANSFER",
       "gas phase": "gas",
       "gas-phase species": "A",
       "condensed phase": "aqueous",

--- a/test/unit/v1/v1_unit_configs/aerosol/valid_aerosol.json
+++ b/test/unit/v1/v1_unit_configs/aerosol/valid_aerosol.json
@@ -40,7 +40,7 @@
   ],
   "aerosol processes": [
     {
-      "type": "HENRY_LAW_PHASE_TRANSFER",
+      "type": "HENRYS_LAW_PHASE_TRANSFER",
       "gas phase": "gas",
       "gas-phase species": "A",
       "condensed phase": "aqueous",
@@ -58,7 +58,7 @@
       "rate constant": { "type": "ARRHENIUS", "A": 1.0e3, "C": 100.0 }
     },
     {
-      "type": "HENRY_LAW_EQUILIBRIUM",
+      "type": "HENRYS_LAW_EQUILIBRIUM",
       "gas phase": "gas",
       "gas-phase species": "A",
       "condensed phase": "aqueous",


### PR DESCRIPTION
This PR updates the naming of Henry's Law code to include the "s", consistent with recent updates to MIAM