### PR TITLE
Make aerosol validation location-aware

### DIFF
--- a/include/mechanism_configuration/validate.hpp
+++ b/include/mechanism_configuration/validate.hpp
@@ -7,106 +7,25 @@
 #include <mechanism_configuration/errors.hpp>
 #include <mechanism_configuration/mechanism.hpp>
 
-#include <optional>
-#include <string>
-#include <vector>
-
 namespace mechanism_configuration
 {
 
-  // Intermediate over which the core semantic validation (species, phases, gas-phase reactions)
-  // runs. Both a parsed document and an in-code Mechanism lower into one of these and hand it to
-  // ValidateSemantics, so those rules live in exactly one place. A parsed document fills in source
-  // locations (so errors carry line:col); an in-code Mechanism leaves them empty.
-  //
-  // Aerosol cross-references are validated separately by ValidateAerosolModel, which works on the
-  // domain structs directly because it needs phase membership and optional-property values that
-  // this name-only view cannot carry.
-  namespace semantics
-  {
-    struct NamedRef
-    {
-      std::string name;
-      std::optional<ErrorLocation> location;
-    };
-
-    struct PhaseRef
-    {
-      std::string name;
-      std::vector<NamedRef> species;
-      std::optional<ErrorLocation> location;
-    };
-
-    struct ReactionRef
-    {
-      std::string type;
-      std::string phase;
-      std::vector<NamedRef> reactants;  // must exist and be registered in `phase`
-      std::vector<NamedRef> products;   // must exist; may belong to any phase
-      std::optional<ErrorLocation> location;
-    };
-
-    struct SpeciesMappingRef
-    {
-      std::string inventory_species;
-      std::string mechanism_species;
-      double scaling_factor{ 1.0 };
-    };
-
-    struct SpeciesMapRef
-    {
-      std::string name;
-      std::vector<SpeciesMappingRef> mappings;
-      std::optional<ErrorLocation> location;
-    };
-
-    struct SourceRef
-    {
-      std::string name;
-      NamedRef inventory;    // .name = referenced inventory name, .location = reference site
-      NamedRef species_map;  // .name = referenced species-map name, .location = reference site
-      int category{ 0 };
-      int hierarchy{ 1 };
-      std::optional<ErrorLocation> location;  // location of the source entry itself
-    };
-
-    struct EmissionsRef
-    {
-      std::vector<NamedRef> inventories;
-      std::vector<SpeciesMapRef> species_maps;
-      std::vector<SourceRef> sources;
-    };
-
-    struct Input
-    {
-      std::vector<NamedRef> species;
-      std::vector<PhaseRef> phases;
-      std::vector<ReactionRef> reactions;
-      std::optional<EmissionsRef> emissions;  // nullopt only when there's no emissions at all
-    };
-
-  }  // namespace semantics
-
-  /// @brief The single home for the core (species / phase / gas-phase reaction) semantic rules.
-  ///        Errors include `line:col` for any element whose source location was supplied.
-  Errors ValidateSemantics(const semantics::Input& input);
-
   /// @brief Validates a Mechanism's species, phases, and gas-phase reactions by
-  ///        converting them to a location-free semantics::Input and running
-  ///        ValidateSemantics.
+  ///        converting them to a location-free semantics::ReactionsInput and running
+  ///        ValidateReactionsSemantics.
   Errors ValidateGasModel(const Mechanism& mechanism);
 
   /// @brief Validates aerosol cross-references against the mechanism's species and phases.
   ///
   ///        Checks phase/species references, representation-keyed rate-constant maps, and
   ///        required definition-derived properties. These validations require full domain
-  ///        information unavailable to ValidateSemantics. Returns no errors if the mechanism
-  ///        has no aerosol section.
+  ///        information unavailable to ValidateReactionsSemantics. Returns no errors if the
+  ///        mechanism has no aerosol section.
   Errors ValidateAerosolModel(const Mechanism& mechanism);
 
   /// @brief Validates a Mechanism's emissions section by converting it to a location-free
-  ///        semantics::Input and running ValidateSemantics. Returns no errors if the mechanism
-  ///        has no emissions section.
+  ///        semantics::EmissionsInput and running ValidateEmissionsSemantics. Returns no errors
+  ///        if the mechanism has no emissions section.
   Errors ValidateEmissionsModel(const Mechanism& mechanism);
 
   /// @brief Validates the semantic invariants of a canonical Mechanism, regardless of whether it

--- a/include/mechanism_configuration/validate.hpp
+++ b/include/mechanism_configuration/validate.hpp
@@ -16,11 +16,8 @@ namespace mechanism_configuration
   Errors ValidateGasModel(const Mechanism& mechanism);
 
   /// @brief Validates aerosol cross-references against the mechanism's species and phases.
-  ///
   ///        Checks phase/species references, representation-keyed rate-constant maps, and
-  ///        required definition-derived properties. These validations require full domain
-  ///        information unavailable to ValidateReactionsSemantics. Returns no errors if the
-  ///        mechanism has no aerosol section.
+  ///        required definition-derived properties.
   Errors ValidateAerosolModel(const Mechanism& mechanism);
 
   /// @brief Validates a Mechanism's emissions section by converting it to a location-free
@@ -31,8 +28,6 @@ namespace mechanism_configuration
   /// @brief Validates the semantic invariants of a canonical Mechanism, regardless of whether it
   ///        was parsed or constructed in code. Combines ValidateGasModel, ValidateAerosolModel,
   ///        and ValidateEmissionsModel, returning all validation errors.
-  ///
-  ///        Excludes structural/deserialization validation, which is handled by version-specific parsers.
   Errors Validate(const Mechanism& mechanism);
 
 }  // namespace mechanism_configuration

--- a/src/detail/semantics/aerosol.hpp
+++ b/src/detail/semantics/aerosol.hpp
@@ -1,0 +1,113 @@
+// Copyright (C) 2023–2026 University Corporation for Atmospheric Research
+//                         University of Illinois at Urbana-Champaign
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "detail/semantics/reactions.hpp"
+
+#include <string>
+#include <vector>
+
+namespace mechanism_configuration::semantics
+{
+  // Not yet wired into ValidateAerosolModel (which still reads mechanism.aerosol directly).
+  // Definitions carry presence flags instead of values: aerosol errors always report at the
+  // reference site (e.g. "solvent 'foo' has no density"), never at the definition site, so
+  // the definition's own location is never needed.
+
+  struct SpeciesDef
+  {
+    std::string name;
+    bool has_molecular_weight{ false };
+  };
+
+  struct PhaseSpeciesDef
+  {
+    std::string name;
+    bool has_diffusion_coefficient{ false };
+    bool has_density{ false };
+  };
+
+  struct PhaseDef
+  {
+    std::string name;
+    std::vector<PhaseSpeciesDef> species;
+  };
+
+  struct AerosolRepresentationRef
+  {
+    std::string name;
+    std::vector<NamedRef> phases;
+  };
+
+  struct DissolvedReactionRef
+  {
+    NamedRef phase;
+    NamedRef solvent;
+    std::vector<NamedRef> reactants;
+    std::vector<NamedRef> products;
+  };
+
+  struct DissolvedReversibleReactionRef
+  {
+    NamedRef phase;
+    NamedRef solvent;
+    std::vector<NamedRef> reactants;
+    std::vector<NamedRef> products;
+  };
+
+  struct HenrysLawPhaseTransferRef
+  {
+    NamedRef gas_phase;
+    NamedRef gas_species;
+    NamedRef condensed_phase;
+    NamedRef condensed_species;
+    NamedRef solvent;
+  };
+
+  struct HenrysLawEquilibriumRef
+  {
+    NamedRef gas_phase;
+    NamedRef gas_species;
+    NamedRef condensed_phase;
+    NamedRef condensed_species;
+    NamedRef solvent;
+  };
+
+  struct DissolvedEquilibriumRef
+  {
+    NamedRef phase;
+    NamedRef algebraic_species;
+    NamedRef solvent;
+    std::vector<NamedRef> reactants;
+    std::vector<NamedRef> products;
+  };
+
+  struct LinearConstraintTermRef
+  {
+    NamedRef phase;
+    NamedRef species;
+  };
+
+  struct LinearConstraintRef
+  {
+    NamedRef algebraic_phase;
+    NamedRef algebraic_species;
+    std::vector<LinearConstraintTermRef> terms;
+  };
+
+  struct AerosolInput
+  {
+    std::vector<SpeciesDef> species;
+    std::vector<PhaseDef> phases;
+    std::vector<AerosolRepresentationRef> representations;
+    std::vector<DissolvedReactionRef> dissolved_reactions;
+    std::vector<DissolvedReversibleReactionRef> dissolved_reversible_reactions;
+    std::vector<HenrysLawPhaseTransferRef> henrys_law_phase_transfers;
+    std::vector<HenrysLawEquilibriumRef> henrys_law_equilibria;
+    std::vector<DissolvedEquilibriumRef> dissolved_equilibria;
+    std::vector<LinearConstraintRef> linear_constraints;
+  };
+
+}  // namespace mechanism_configuration::semantics

--- a/src/detail/semantics/aerosol.hpp
+++ b/src/detail/semantics/aerosol.hpp
@@ -4,18 +4,15 @@
 
 #pragma once
 
-#include "detail/semantics/reactions.hpp"
+#include "detail/semantics/core.hpp"
 
+#include <optional>
 #include <string>
 #include <vector>
 
 namespace mechanism_configuration::semantics
 {
-  // Not yet wired into ValidateAerosolModel (which still reads mechanism.aerosol directly).
-  // Definitions carry presence flags instead of values: aerosol errors always report at the
-  // reference site (e.g. "solvent 'foo' has no density"), never at the definition site, so
-  // the definition's own location is never needed.
-
+  // Definitions carry presence flags.
   struct SpeciesDef
   {
     std::string name;
@@ -39,6 +36,7 @@ namespace mechanism_configuration::semantics
   {
     std::string name;
     std::vector<NamedRef> phases;
+    std::optional<ErrorLocation> location;
   };
 
   struct DissolvedReactionRef
@@ -47,6 +45,7 @@ namespace mechanism_configuration::semantics
     NamedRef solvent;
     std::vector<NamedRef> reactants;
     std::vector<NamedRef> products;
+    std::optional<ErrorLocation> location;
   };
 
   struct DissolvedReversibleReactionRef
@@ -55,6 +54,7 @@ namespace mechanism_configuration::semantics
     NamedRef solvent;
     std::vector<NamedRef> reactants;
     std::vector<NamedRef> products;
+    std::optional<ErrorLocation> location;
   };
 
   struct HenrysLawPhaseTransferRef
@@ -64,6 +64,7 @@ namespace mechanism_configuration::semantics
     NamedRef condensed_phase;
     NamedRef condensed_species;
     NamedRef solvent;
+    std::optional<ErrorLocation> location;
   };
 
   struct HenrysLawEquilibriumRef
@@ -73,6 +74,7 @@ namespace mechanism_configuration::semantics
     NamedRef condensed_phase;
     NamedRef condensed_species;
     NamedRef solvent;
+    std::optional<ErrorLocation> location;
   };
 
   struct DissolvedEquilibriumRef
@@ -82,6 +84,7 @@ namespace mechanism_configuration::semantics
     NamedRef solvent;
     std::vector<NamedRef> reactants;
     std::vector<NamedRef> products;
+    std::optional<ErrorLocation> location;
   };
 
   struct LinearConstraintTermRef
@@ -95,6 +98,7 @@ namespace mechanism_configuration::semantics
     NamedRef algebraic_phase;
     NamedRef algebraic_species;
     std::vector<LinearConstraintTermRef> terms;
+    std::optional<ErrorLocation> location;
   };
 
   struct AerosolInput
@@ -111,3 +115,12 @@ namespace mechanism_configuration::semantics
   };
 
 }  // namespace mechanism_configuration::semantics
+
+namespace mechanism_configuration
+{
+  /// @brief Validates aerosol cross-references: phase/species membership (representations,
+  ///        dissolved reactions/equilibria, Henry's-law transfers/equilibria, linear constraint
+  ///        terms) and required definition-derived properties (molecular weight, diffusion
+  ///        coefficient, density).
+  Errors ValidateAerosolSemantics(const semantics::AerosolInput& input);
+}  // namespace mechanism_configuration

--- a/src/detail/semantics/core.hpp
+++ b/src/detail/semantics/core.hpp
@@ -1,0 +1,22 @@
+// Copyright (C) 2023–2026 University Corporation for Atmospheric Research
+//                         University of Illinois at Urbana-Champaign
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <mechanism_configuration/errors.hpp>
+
+#include <optional>
+#include <string>
+
+namespace mechanism_configuration::semantics
+{
+  // A referenced name and its source location. Parsed documents populate the location
+  // (line:col for error reporting) and in-code Mechanism leaves it empty.
+  struct NamedRef
+  {
+    std::string name;
+    std::optional<ErrorLocation> location;
+  };
+
+}  // namespace mechanism_configuration::semantics

--- a/src/detail/semantics/emissions.hpp
+++ b/src/detail/semantics/emissions.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "detail/semantics/reactions.hpp"
+#include "detail/semantics/core.hpp"
 
 #include <optional>
 #include <string>

--- a/src/detail/semantics/emissions.hpp
+++ b/src/detail/semantics/emissions.hpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2023–2026 University Corporation for Atmospheric Research
+//                         University of Illinois at Urbana-Champaign
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "detail/semantics/reactions.hpp"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace mechanism_configuration::semantics
+{
+  struct SpeciesMappingRef
+  {
+    std::string inventory_species;
+    std::string mechanism_species;
+    double scaling_factor{ 1.0 };
+  };
+
+  struct SpeciesMapRef
+  {
+    std::string name;
+    std::vector<SpeciesMappingRef> mappings;
+    std::optional<ErrorLocation> location;
+  };
+
+  struct SourceRef
+  {
+    std::string name;
+    NamedRef inventory;    // .name = referenced inventory name, .location = reference site
+    NamedRef species_map;  // .name = referenced species-map name, .location = reference site
+    int category{ 0 };
+    int hierarchy{ 1 };
+    std::optional<ErrorLocation> location;  // location of the source entry itself
+  };
+
+  struct EmissionsInput
+  {
+    std::vector<NamedRef> inventories;
+    std::vector<SpeciesMapRef> species_maps;
+    std::vector<SourceRef> sources;
+  };
+
+}  // namespace mechanism_configuration::semantics
+
+namespace mechanism_configuration
+{
+  /// @brief Validates an emissions section: duplicate names, source cross-references (inventory /
+  ///        species-map existence), duplicate (category, hierarchy) pairs, and species-map
+  ///        scaling-factor sums. Independent of ValidateReactionsSemantics — emissions never
+  ///        cross-references species or phases.
+  Errors ValidateEmissionsSemantics(const semantics::EmissionsInput& input);
+}  // namespace mechanism_configuration

--- a/src/detail/semantics/reactions.hpp
+++ b/src/detail/semantics/reactions.hpp
@@ -1,0 +1,64 @@
+// Copyright (C) 2023–2026 University Corporation for Atmospheric Research
+//                         University of Illinois at Urbana-Champaign
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <mechanism_configuration/errors.hpp>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace mechanism_configuration::semantics
+{
+
+  // Intermediate over which the core semantic validation (species, phases, gas-phase reactions)
+  // runs. Both a parsed document and an in-code Mechanism lower into one of these and hand it to
+  // ValidateReactionsSemantics, so those rules live in exactly one place. A parsed document fills
+  // in source locations (so errors carry line:col); an in-code Mechanism leaves them empty.
+  //
+  // Emissions and aerosol cross-references each have their own separate engine (see
+  // detail/semantics/emissions.hpp and detail/semantics/aerosol.hpp) — neither one ever
+  // cross-references species/phases collected here, so bundling them into this Input would be
+  // shared plumbing, not a shared rule set.
+  //
+  // This is an implementation detail of ValidateGasModel
+  // (declared publicly in <mechanism_configuration/validate.hpp>) and is not part of the public API.
+  struct NamedRef
+  {
+    std::string name;
+    std::optional<ErrorLocation> location;
+  };
+
+  struct PhaseRef
+  {
+    std::string name;
+    std::vector<NamedRef> species;
+    std::optional<ErrorLocation> location;
+  };
+
+  struct ReactionRef
+  {
+    std::string type;
+    std::string phase;
+    std::vector<NamedRef> reactants;  // must exist and be registered in `phase`
+    std::vector<NamedRef> products;   // must exist; may belong to any phase
+    std::optional<ErrorLocation> location;
+  };
+
+  struct ReactionsInput
+  {
+    std::vector<NamedRef> species;
+    std::vector<PhaseRef> phases;
+    std::vector<ReactionRef> reactions;
+  };
+}  // namespace mechanism_configuration::semantics
+
+namespace mechanism_configuration
+{
+  /// @brief The single home for the core (species / phase / gas-phase reaction) semantic rules.
+  ///        Errors include `line:col` for any element whose source location was supplied.
+  Errors ValidateReactionsSemantics(const semantics::ReactionsInput& input);
+
+}  // namespace mechanism_configuration

--- a/src/detail/semantics/reactions.hpp
+++ b/src/detail/semantics/reactions.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "detail/semantics/core.hpp"
+
 #include <mechanism_configuration/errors.hpp>
 
 #include <optional>
@@ -25,12 +27,6 @@ namespace mechanism_configuration::semantics
   //
   // This is an implementation detail of ValidateGasModel
   // (declared publicly in <mechanism_configuration/validate.hpp>) and is not part of the public API.
-  struct NamedRef
-  {
-    std::string name;
-    std::optional<ErrorLocation> location;
-  };
-
   struct PhaseRef
   {
     std::string name;

--- a/src/detail/semantics/reactions.hpp
+++ b/src/detail/semantics/reactions.hpp
@@ -14,19 +14,6 @@
 
 namespace mechanism_configuration::semantics
 {
-
-  // Intermediate over which the core semantic validation (species, phases, gas-phase reactions)
-  // runs. Both a parsed document and an in-code Mechanism lower into one of these and hand it to
-  // ValidateReactionsSemantics, so those rules live in exactly one place. A parsed document fills
-  // in source locations (so errors carry line:col); an in-code Mechanism leaves them empty.
-  //
-  // Emissions and aerosol cross-references each have their own separate engine (see
-  // detail/semantics/emissions.hpp and detail/semantics/aerosol.hpp) — neither one ever
-  // cross-references species/phases collected here, so bundling them into this Input would be
-  // shared plumbing, not a shared rule set.
-  //
-  // This is an implementation detail of ValidateGasModel
-  // (declared publicly in <mechanism_configuration/validate.hpp>) and is not part of the public API.
   struct PhaseRef
   {
     std::string name;
@@ -53,8 +40,8 @@ namespace mechanism_configuration::semantics
 
 namespace mechanism_configuration
 {
-  /// @brief The single home for the core (species / phase / gas-phase reaction) semantic rules.
-  ///        Errors include `line:col` for any element whose source location was supplied.
+  /// @brief Validates species, phase, gas-phase reaction semantic rules.
+  ///        Errors include `line:col` when the source location is available.
   Errors ValidateReactionsSemantics(const semantics::ReactionsInput& input);
 
 }  // namespace mechanism_configuration

--- a/src/detail/v1/aerosol/schema.hpp
+++ b/src/detail/v1/aerosol/schema.hpp
@@ -17,7 +17,7 @@ namespace mechanism_configuration::v1
 
   /// @brief Schema-validates each entry of the aerosol processes section which mixes
   ///        process and constraint types. Structural only; cross-references against species and
-  ///        phases (membership, sourced properties) are checked separately by ValidateAerosolModel.
+  ///        phases (membership, sourced properties) are checked separately by ValidateAerosolSemantics.
   /// @param processes_list YAML node containing the process/constraint entries
   /// @return List of structural errors, or empty if all entries conform
   Errors CheckAerosolProcessesSchema(const YAML::Node& processes_list);

--- a/src/detail/v1/emissions/schema.hpp
+++ b/src/detail/v1/emissions/schema.hpp
@@ -13,7 +13,7 @@ namespace mechanism_configuration::v1
   // Structural (schema) validation of the emissions section. Checks required/optional keys,
   // value shape, and fixed-enum-membership only; semantic invariants (duplicate names, unknown
   // inventory/species-map references, scaling-factor sums) are checked separately by the
-  // version-neutral ValidateSemantics on the built Mechanism.
+  // version-neutral ValidateEmissionsSemantics on the built Mechanism.
 
   /// @brief Schema-validates the emissions section: inventories, species maps (and their
   ///        mappings), regridding, and sources.

--- a/src/detail/v1/parser.hpp
+++ b/src/detail/v1/parser.hpp
@@ -27,8 +27,7 @@ namespace mechanism_configuration::v1
   /// @brief Extracts a located semantics::AerosolInput from a fully-resolved (inline) v1 YAML
   ///        node, so ValidateAerosolSemantics can run with line:col. Species/phase definitions
   ///        are always populated; representations/processes/constraints are only populated when
-  ///        both `aerosol representations` and `aerosol processes` are present, matching the
-  ///        gating Build() uses to decide whether mechanism.aerosol gets set at all.
+  ///        both `aerosol representations` and `aerosol processes` are present.
   semantics::AerosolInput BuildAerosolSemanticInput(const YAML::Node& object);
 
   /// @brief Extracts a located semantics::EmissionsInput from a fully-resolved (inline) v1 YAML
@@ -70,9 +69,7 @@ namespace mechanism_configuration::v1
     ///        mapping any thrown exception to an error. Uses config_path_ for message prefixes.
     std::expected<Mechanism, Errors> ValidateAndBuild(const YAML::Node& object);
 
-    /// @brief Checks the structural schema of a mechanism YAML node (keys/shape only). Semantic
-    ///        invariants are checked separately by ValidateReactionsSemantics/
-    ///        ValidateEmissionsSemantics/ValidateAerosolSemantics.
+    /// @brief Checks the structural schema of a mechanism YAML node (keys/shape only).
     Errors CheckSchema(const YAML::Node& object);
 
     /// @brief Constructs a Mechanism from an already-validated node. The emissions section, if

--- a/src/detail/v1/parser.hpp
+++ b/src/detail/v1/parser.hpp
@@ -4,8 +4,9 @@
 
 #pragma once
 
-#include "detail/semantics/reactions.hpp"
+#include "detail/semantics/aerosol.hpp"
 #include "detail/semantics/emissions.hpp"
+#include "detail/semantics/reactions.hpp"
 
 #include <mechanism_configuration/mechanism.hpp>
 #include <mechanism_configuration/validate.hpp>
@@ -21,7 +22,14 @@ namespace mechanism_configuration::v1
   /// @brief Extracts a located semantics::ReactionsInput from a fully-resolved (inline) v1 YAML
   ///        node, so the version-neutral ValidateReactionsSemantics can run the semantic checks
   ///        with line:col.
-  semantics::ReactionsInput BuildSemanticInput(const YAML::Node& object);
+  semantics::ReactionsInput BuildReactionsSemanticInput(const YAML::Node& object);
+
+  /// @brief Extracts a located semantics::AerosolInput from a fully-resolved (inline) v1 YAML
+  ///        node, so ValidateAerosolSemantics can run with line:col. Species/phase definitions
+  ///        are always populated; representations/processes/constraints are only populated when
+  ///        both `aerosol representations` and `aerosol processes` are present, matching the
+  ///        gating Build() uses to decide whether mechanism.aerosol gets set at all.
+  semantics::AerosolInput BuildAerosolSemanticInput(const YAML::Node& object);
 
   /// @brief Extracts a located semantics::EmissionsInput from a fully-resolved (inline) v1 YAML
   ///        node, so ValidateEmissionsSemantics can run with line:col. Returns a default-empty
@@ -63,7 +71,8 @@ namespace mechanism_configuration::v1
     std::expected<Mechanism, Errors> ValidateAndBuild(const YAML::Node& object);
 
     /// @brief Checks the structural schema of a mechanism YAML node (keys/shape only). Semantic
-    ///        invariants are checked separately by ValidateReactionsSemantics/ValidateEmissionsSemantics.
+    ///        invariants are checked separately by ValidateReactionsSemantics/
+    ///        ValidateEmissionsSemantics/ValidateAerosolSemantics.
     Errors CheckSchema(const YAML::Node& object);
 
     /// @brief Constructs a Mechanism from an already-validated node. The emissions section, if

--- a/src/detail/v1/parser.hpp
+++ b/src/detail/v1/parser.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include "detail/semantics/reactions.hpp"
+#include "detail/semantics/emissions.hpp"
+
 #include <mechanism_configuration/mechanism.hpp>
 #include <mechanism_configuration/validate.hpp>
 
@@ -15,9 +18,15 @@
 
 namespace mechanism_configuration::v1
 {
-  /// @brief Extracts a located semantics::Input from a fully-resolved (inline) v1 YAML node, so
-  ///        the version-neutral ValidateSemantics can run the semantic checks with line:col.
-  semantics::Input BuildSemanticInput(const YAML::Node& object);
+  /// @brief Extracts a located semantics::ReactionsInput from a fully-resolved (inline) v1 YAML
+  ///        node, so the version-neutral ValidateReactionsSemantics can run the semantic checks
+  ///        with line:col.
+  semantics::ReactionsInput BuildSemanticInput(const YAML::Node& object);
+
+  /// @brief Extracts a located semantics::EmissionsInput from a fully-resolved (inline) v1 YAML
+  ///        node, so ValidateEmissionsSemantics can run with line:col. Returns a default-empty
+  ///        EmissionsInput (validates with no errors) when the document has no `emissions` key.
+  semantics::EmissionsInput BuildEmissionsSemanticInput(const YAML::Node& object);
 
   class Parser
   {
@@ -54,7 +63,7 @@ namespace mechanism_configuration::v1
     std::expected<Mechanism, Errors> ValidateAndBuild(const YAML::Node& object);
 
     /// @brief Checks the structural schema of a mechanism YAML node (keys/shape only). Semantic
-    ///        invariants are checked separately by ValidateSemantics.
+    ///        invariants are checked separately by ValidateReactionsSemantics/ValidateEmissionsSemantics.
     Errors CheckSchema(const YAML::Node& object);
 
     /// @brief Constructs a Mechanism from an already-validated node. The emissions section, if

--- a/src/detail/v1/reactions/schema.hpp
+++ b/src/detail/v1/reactions/schema.hpp
@@ -15,7 +15,7 @@ namespace mechanism_configuration::v1
 {
   // Structural (schema) validation of v1 reactions. These check required/optional keys and value
   // shape only; semantic invariants (duplicate names, unknown species, phase membership) are
-  // checked separately by the version-neutral ValidateSemantics on the built Mechanism.
+  // checked separately by the version-neutral ValidateReactionsSemantics on the built Mechanism.
 
   /// @brief Schema-validates a sequence of reaction components (reactants or products),
   ///        requiring exactly one of `name` / `species name` plus an optional coefficient.

--- a/src/detail/v1/species/schema.hpp
+++ b/src/detail/v1/species/schema.hpp
@@ -15,7 +15,7 @@ namespace mechanism_configuration::v1
 {
   // Structural (schema) validation of v1 species and phases. These check required/optional keys
   // and value shape only; semantic invariants (duplicate names, unknown species, phase membership)
-  // are checked separately by the version-neutral ValidateSemantics on the built Mechanism.
+  // are checked separately by the version-neutral ValidateReactionsSemantics on the built Mechanism.
 
   /// @brief Schema-validates each species entry's keys.
   /// @param species_list YAML node containing species entries

--- a/src/v1/aerosol/parsers.cpp
+++ b/src/v1/aerosol/parsers.cpp
@@ -133,8 +133,9 @@ namespace mechanism_configuration::v1
     transfer.condensed_species = object[keys::condensed_phase_species].as<std::string>();
     transfer.solvent = object[keys::solvent].as<std::string>();
     transfer.henrys_law_constant = ParseHenrysLawConstant(object[keys::henrys_law_constant]);
-    // Sourced from the gas-phase species' definition; presence is enforced by ValidateAerosolModel,
-    // which runs before this result is returned, so a missing value defaults harmlessly here.
+    // Sourced from the gas-phase species' definition; presence is enforced by
+    // ValidateAerosolSemantics, which runs before this parser is ever reached (in
+    // Parser::ValidateAndBuild), so a missing value defaults harmlessly here.
     transfer.diffusion_coefficient =
         FindPhaseSpeciesDiffusionCoefficient(phases, transfer.gas_phase, transfer.gas_species).value_or(0.0);
     transfer.accommodation_coefficient = object[keys::accommodation_coefficient].as<double>();
@@ -195,8 +196,9 @@ namespace mechanism_configuration::v1
     equilibrium.henrys_law_constant = ParseHenrysLawConstant(object[keys::henrys_law_constant]);
 
     // Sourced from the solvent species' definition: molecular weight from the species section,
-    // density from the condensed phase. Presence is enforced by ValidateAerosolModel, which runs
-    // before this result is returned, so a missing value defaults harmlessly here.
+    // density from the condensed phase. Presence is enforced by ValidateAerosolSemantics, which
+    // runs before this parser is ever reached (in Parser::ValidateAndBuild), so a missing value
+    // defaults harmlessly here.
     equilibrium.solvent_molecular_weight = FindSpeciesMolecularWeight(species, equilibrium.solvent).value_or(0.0);
     equilibrium.solvent_density =
         FindPhaseSpeciesDensity(phases, equilibrium.condensed_phase, equilibrium.solvent).value_or(0.0);

--- a/src/v1/aerosol/schema.cpp
+++ b/src/v1/aerosol/schema.cpp
@@ -138,7 +138,7 @@ namespace mechanism_configuration::v1
       if (type == keys::HenrysLawPhaseTransfer_key)
       {
         // The diffusion coefficient is not given here. It is sourced from the gas-phase
-        // species' definition in the phases section (see ValidateAerosolModel).
+        // species' definition in the phases section (see ValidateAerosolSemantics).
         required_keys = { keys::type,
                           keys::gas_phase,
                           keys::gas_phase_species,
@@ -203,7 +203,7 @@ namespace mechanism_configuration::v1
       else if (type == keys::HenrysLawEquilibrium_key)
       {
         // The solvent's molecular weight and density are not given here; they are sourced from
-        // the solvent species' definition (see ValidateAerosolModel).
+        // the solvent species' definition (see ValidateAerosolSemantics).
         required_keys = { keys::type,
                           keys::gas_phase,
                           keys::gas_phase_species,

--- a/src/v1/parser.cpp
+++ b/src/v1/parser.cpp
@@ -60,9 +60,9 @@ namespace mechanism_configuration::v1
     }
   }  // namespace
 
-  semantics::Input BuildSemanticInput(const YAML::Node& object)
+  semantics::ReactionsInput BuildSemanticInput(const YAML::Node& object)
   {
-    semantics::Input input;
+    semantics::ReactionsInput input;
 
     if (object[std::string(keys::species)])
       for (const auto& s : object[std::string(keys::species)])
@@ -102,53 +102,57 @@ namespace mechanism_configuration::v1
         input.reactions.push_back(std::move(rr));
       }
 
-    if (object[std::string(keys::emissions)])
-    {
-      const YAML::Node& emissions_node = object[std::string(keys::emissions)];
-      semantics::EmissionsRef emissions_ref;
+    return input;
+  }
 
-      if (emissions_node[std::string(keys::inventories)])
-        for (const auto& item : emissions_node[std::string(keys::inventories)])
-          emissions_ref.inventories.push_back({ item[std::string(keys::name)].as<std::string>(), LocationOf(item) });
+  semantics::EmissionsInput BuildEmissionsSemanticInput(const YAML::Node& object)
+  {
+    semantics::EmissionsInput input;
 
-      if (emissions_node[std::string(keys::species_maps)])
-        for (const auto& item : emissions_node[std::string(keys::species_maps)])
-        {
-          semantics::SpeciesMapRef smap_ref;
-          smap_ref.name = item[std::string(keys::name)].as<std::string>();
-          smap_ref.location = LocationOf(item);
-          if (item[std::string(keys::mappings)])
-            for (const auto& mapping_node : item[std::string(keys::mappings)])
-            {
-              semantics::SpeciesMappingRef mapping_ref;
-              mapping_ref.inventory_species = mapping_node[std::string(keys::inventory_species)].as<std::string>();
-              mapping_ref.mechanism_species = mapping_node[std::string(keys::mechanism_species)].as<std::string>();
-              if (mapping_node[std::string(keys::scaling_factor)])
-                mapping_ref.scaling_factor = mapping_node[std::string(keys::scaling_factor)].as<double>();
-              smap_ref.mappings.push_back(std::move(mapping_ref));
-            }
-          emissions_ref.species_maps.push_back(std::move(smap_ref));
-        }
+    if (!object[std::string(keys::emissions)])
+      return input;
 
-      if (emissions_node[std::string(keys::sources)])
-        for (const auto& item : emissions_node[std::string(keys::sources)])
-        {
-          semantics::SourceRef source_ref;
-          source_ref.name = item[std::string(keys::name)].as<std::string>();
-          source_ref.location = LocationOf(item);
-          source_ref.inventory = { item[std::string(keys::inventory)].as<std::string>(),
-                                   LocationOf(item[std::string(keys::inventory)]) };
-          source_ref.species_map = { item[std::string(keys::species_map)].as<std::string>(),
-                                     LocationOf(item[std::string(keys::species_map)]) };
-          if (item[std::string(keys::category)])
-            source_ref.category = item[std::string(keys::category)].as<int>();
-          if (item[std::string(keys::hierarchy)])
-            source_ref.hierarchy = item[std::string(keys::hierarchy)].as<int>();
-          emissions_ref.sources.push_back(std::move(source_ref));
-        }
+    const YAML::Node& emissions_node = object[std::string(keys::emissions)];
 
-      input.emissions = std::move(emissions_ref);
-    }
+    if (emissions_node[std::string(keys::inventories)])
+      for (const auto& item : emissions_node[std::string(keys::inventories)])
+        input.inventories.push_back({ item[std::string(keys::name)].as<std::string>(), LocationOf(item) });
+
+    if (emissions_node[std::string(keys::species_maps)])
+      for (const auto& item : emissions_node[std::string(keys::species_maps)])
+      {
+        semantics::SpeciesMapRef smap_ref;
+        smap_ref.name = item[std::string(keys::name)].as<std::string>();
+        smap_ref.location = LocationOf(item);
+        if (item[std::string(keys::mappings)])
+          for (const auto& mapping_node : item[std::string(keys::mappings)])
+          {
+            semantics::SpeciesMappingRef mapping_ref;
+            mapping_ref.inventory_species = mapping_node[std::string(keys::inventory_species)].as<std::string>();
+            mapping_ref.mechanism_species = mapping_node[std::string(keys::mechanism_species)].as<std::string>();
+            if (mapping_node[std::string(keys::scaling_factor)])
+              mapping_ref.scaling_factor = mapping_node[std::string(keys::scaling_factor)].as<double>();
+            smap_ref.mappings.push_back(std::move(mapping_ref));
+          }
+        input.species_maps.push_back(std::move(smap_ref));
+      }
+
+    if (emissions_node[std::string(keys::sources)])
+      for (const auto& item : emissions_node[std::string(keys::sources)])
+      {
+        semantics::SourceRef source_ref;
+        source_ref.name = item[std::string(keys::name)].as<std::string>();
+        source_ref.location = LocationOf(item);
+        source_ref.inventory = { item[std::string(keys::inventory)].as<std::string>(),
+                                 LocationOf(item[std::string(keys::inventory)]) };
+        source_ref.species_map = { item[std::string(keys::species_map)].as<std::string>(),
+                                   LocationOf(item[std::string(keys::species_map)]) };
+        if (item[std::string(keys::category)])
+          source_ref.category = item[std::string(keys::category)].as<int>();
+        if (item[std::string(keys::hierarchy)])
+          source_ref.hierarchy = item[std::string(keys::hierarchy)].as<int>();
+        input.sources.push_back(std::move(source_ref));
+      }
 
     return input;
   }
@@ -440,12 +444,16 @@ namespace mechanism_configuration::v1
       Errors errors = CheckSchema(object);
 
       // 2) Semantic validation — needs a structurally-valid document, so only run it when
-      //    the structure is clean. Located via BuildSemanticInput so errors carry line:col.
+      //    the structure is clean. Located via BuildSemanticInput/BuildEmissionsSemanticInput so
+      //    errors carry line:col.
       if (errors.empty())
       {
-        // Uses the same ValidateSemantics engine as ValidateGasModel, but with
-        // YAML-derived input so errors include source locations.
-        auto semantic_errors = ValidateSemantics(BuildSemanticInput(object));
+        // Uses the same ValidateReactionsSemantics/ValidateEmissionsSemantics engines as
+        // ValidateGasModel/ValidateEmissionsModel, but with YAML-derived input so errors include
+        // source locations.
+        auto semantic_errors = ValidateReactionsSemantics(BuildSemanticInput(object));
+        auto emissions_errors = ValidateEmissionsSemantics(BuildEmissionsSemanticInput(object));
+        semantic_errors.insert(semantic_errors.end(), emissions_errors.begin(), emissions_errors.end());
         AppendFilePath(config_path_, semantic_errors);
         errors.insert(errors.end(), semantic_errors.begin(), semantic_errors.end());
       }

--- a/src/v1/parser.cpp
+++ b/src/v1/parser.cpp
@@ -15,6 +15,7 @@
 #include "detail/v1/keys.hpp"
 #include "detail/v1/reactions/parsers.hpp"
 #include "detail/v1/reactions/schema.hpp"
+#include "detail/v1/species/keys.hpp"
 #include "detail/v1/species/parsers.hpp"
 #include "detail/v1/species/schema.hpp"
 #include "detail/v1/utils.hpp"
@@ -60,7 +61,7 @@ namespace mechanism_configuration::v1
     }
   }  // namespace
 
-  semantics::ReactionsInput BuildSemanticInput(const YAML::Node& object)
+  semantics::ReactionsInput BuildReactionsSemanticInput(const YAML::Node& object)
   {
     semantics::ReactionsInput input;
 
@@ -101,6 +102,143 @@ namespace mechanism_configuration::v1
         CollectComponents(reaction, keys::gas_phase_products, rr.products);
         input.reactions.push_back(std::move(rr));
       }
+
+    return input;
+  }
+
+  semantics::AerosolInput BuildAerosolSemanticInput(const YAML::Node& object)
+  {
+    semantics::AerosolInput input;
+
+    if (object[std::string(keys::species)])
+      for (const auto& s : object[std::string(keys::species)])
+        input.species.push_back({ GetComponentName(s), static_cast<bool>(s[std::string(keys::molecular_weight)]) });
+
+    if (object[std::string(keys::phases)])
+      for (const auto& phase : object[std::string(keys::phases)])
+      {
+        semantics::PhaseDef phase_def;
+        phase_def.name = phase[std::string(keys::name)].as<std::string>();
+        if (phase[std::string(keys::species)])
+          for (const auto& ps : phase[std::string(keys::species)])
+          {
+            semantics::PhaseSpeciesDef ps_def;
+            ps_def.name = GetComponentName(ps);
+            if (!ps.IsScalar())
+            {
+              ps_def.has_diffusion_coefficient = static_cast<bool>(ps[std::string(keys::diffusion_coefficient)]);
+              ps_def.has_density = static_cast<bool>(ps[std::string(keys::density)]);
+            }
+            phase_def.species.push_back(std::move(ps_def));
+          }
+        input.phases.push_back(std::move(phase_def));
+      }
+
+    // Sets mechanism.aerosol when both keys are present, avoiding errors for references omitted from the built Mechanism.
+    if (!(object[std::string(keys::aerosol_representations)] && object[std::string(keys::aerosol_processes)]))
+      return input;
+
+    for (const auto& rep_node : object[std::string(keys::aerosol_representations)])
+    {
+      semantics::AerosolRepresentationRef ref;
+      ref.name = rep_node[std::string(keys::name)].as<std::string>();
+      ref.location = LocationOf(rep_node);
+      if (rep_node[std::string(keys::phases)])
+        for (const auto& phase_node : rep_node[std::string(keys::phases)])
+          ref.phases.push_back({ phase_node.as<std::string>(), LocationOf(phase_node) });
+      input.representations.push_back(std::move(ref));
+    }
+
+    for (const auto& entry : object[std::string(keys::aerosol_processes)])
+    {
+      const auto type = entry[std::string(keys::type)].as<std::string>();
+
+      if (type == keys::HenrysLawPhaseTransfer_key)
+      {
+        semantics::HenrysLawPhaseTransferRef ref;
+        ref.gas_phase = { entry[std::string(keys::gas_phase)].as<std::string>(),
+                          LocationOf(entry[std::string(keys::gas_phase)]) };
+        ref.gas_species = { entry[std::string(keys::gas_phase_species)].as<std::string>(),
+                            LocationOf(entry[std::string(keys::gas_phase_species)]) };
+        ref.condensed_phase = { entry[std::string(keys::condensed_phase)].as<std::string>(),
+                                LocationOf(entry[std::string(keys::condensed_phase)]) };
+        ref.condensed_species = { entry[std::string(keys::condensed_phase_species)].as<std::string>(),
+                                  LocationOf(entry[std::string(keys::condensed_phase_species)]) };
+        ref.solvent = { entry[std::string(keys::solvent)].as<std::string>(), LocationOf(entry[std::string(keys::solvent)]) };
+        ref.location = LocationOf(entry);
+        input.henrys_law_phase_transfers.push_back(std::move(ref));
+      }
+      else if (type == keys::DissolvedReaction_key)
+      {
+        semantics::DissolvedReactionRef ref;
+        ref.phase = { entry[std::string(keys::condensed_phase)].as<std::string>(),
+                      LocationOf(entry[std::string(keys::condensed_phase)]) };
+        ref.solvent = { entry[std::string(keys::solvent)].as<std::string>(), LocationOf(entry[std::string(keys::solvent)]) };
+        CollectComponents(entry, keys::reactants, ref.reactants);
+        CollectComponents(entry, keys::products, ref.products);
+        ref.location = LocationOf(entry);
+        input.dissolved_reactions.push_back(std::move(ref));
+      }
+      else if (type == keys::DissolvedReversibleReaction_key)
+      {
+        semantics::DissolvedReversibleReactionRef ref;
+        ref.phase = { entry[std::string(keys::condensed_phase)].as<std::string>(),
+                      LocationOf(entry[std::string(keys::condensed_phase)]) };
+        ref.solvent = { entry[std::string(keys::solvent)].as<std::string>(), LocationOf(entry[std::string(keys::solvent)]) };
+        CollectComponents(entry, keys::reactants, ref.reactants);
+        CollectComponents(entry, keys::products, ref.products);
+        ref.location = LocationOf(entry);
+        input.dissolved_reversible_reactions.push_back(std::move(ref));
+      }
+      else if (type == keys::HenrysLawEquilibrium_key)
+      {
+        semantics::HenrysLawEquilibriumRef ref;
+        ref.gas_phase = { entry[std::string(keys::gas_phase)].as<std::string>(),
+                          LocationOf(entry[std::string(keys::gas_phase)]) };
+        ref.gas_species = { entry[std::string(keys::gas_phase_species)].as<std::string>(),
+                            LocationOf(entry[std::string(keys::gas_phase_species)]) };
+        ref.condensed_phase = { entry[std::string(keys::condensed_phase)].as<std::string>(),
+                                LocationOf(entry[std::string(keys::condensed_phase)]) };
+        ref.condensed_species = { entry[std::string(keys::condensed_phase_species)].as<std::string>(),
+                                  LocationOf(entry[std::string(keys::condensed_phase_species)]) };
+        ref.solvent = { entry[std::string(keys::solvent)].as<std::string>(), LocationOf(entry[std::string(keys::solvent)]) };
+        ref.location = LocationOf(entry);
+        input.henrys_law_equilibria.push_back(std::move(ref));
+      }
+      else if (type == keys::DissolvedEquilibrium_key)
+      {
+        semantics::DissolvedEquilibriumRef ref;
+        ref.phase = { entry[std::string(keys::condensed_phase)].as<std::string>(),
+                      LocationOf(entry[std::string(keys::condensed_phase)]) };
+        ref.algebraic_species = { entry[std::string(keys::algebraic_species)].as<std::string>(),
+                                  LocationOf(entry[std::string(keys::algebraic_species)]) };
+        ref.solvent = { entry[std::string(keys::solvent)].as<std::string>(), LocationOf(entry[std::string(keys::solvent)]) };
+        CollectComponents(entry, keys::reactants, ref.reactants);
+        CollectComponents(entry, keys::products, ref.products);
+        ref.location = LocationOf(entry);
+        input.dissolved_equilibria.push_back(std::move(ref));
+      }
+      else if (type == keys::LinearConstraint_key)
+      {
+        semantics::LinearConstraintRef ref;
+        ref.algebraic_phase = { entry[std::string(keys::algebraic_phase)].as<std::string>(),
+                                LocationOf(entry[std::string(keys::algebraic_phase)]) };
+        ref.algebraic_species = { entry[std::string(keys::algebraic_species)].as<std::string>(),
+                                  LocationOf(entry[std::string(keys::algebraic_species)]) };
+        if (entry[std::string(keys::terms)])
+          for (const auto& term_node : entry[std::string(keys::terms)])
+          {
+            semantics::LinearConstraintTermRef term_ref;
+            term_ref.phase = { term_node[std::string(keys::phase)].as<std::string>(),
+                               LocationOf(term_node[std::string(keys::phase)]) };
+            term_ref.species = { term_node[std::string(keys::name)].as<std::string>(),
+                                 LocationOf(term_node[std::string(keys::name)]) };
+            ref.terms.push_back(std::move(term_ref));
+          }
+        ref.location = LocationOf(entry);
+        input.linear_constraints.push_back(std::move(ref));
+      }
+    }
 
     return input;
   }
@@ -272,9 +410,6 @@ namespace mechanism_configuration::v1
   {
     Errors errors;
 
-    // A single configuration can contain both gas-phase reactions and aerosol processes.
-    // Since aerosol chemistry does not always require gas-phase reactions, either section
-    // may be omitted, making both configurations optional.
     std::vector<std::string_view> required_keys = { keys::version, keys::species, keys::phases };
     std::vector<std::string_view> optional_keys = {
       keys::name, keys::reactions, keys::aerosol_representations, keys::aerosol_processes, keys::emissions
@@ -357,9 +492,6 @@ namespace mechanism_configuration::v1
 
     auto parsed_phases = ParsePhases(object[keys::phases]);
 
-    // Reactions and aerosol sections are independent, so we accumulate errors from both and report
-    // them together.
-
     // Gas-phase reactions are optional (an aerosol-only config may omit them).
     if (has_reactions)
     {
@@ -440,19 +572,17 @@ namespace mechanism_configuration::v1
   {
     try
     {
-      // 1) Structural (schema) validation.
+      // Structural (schema) validation.
       Errors errors = CheckSchema(object);
 
-      // 2) Semantic validation — needs a structurally-valid document, so only run it when
-      //    the structure is clean. Located via BuildSemanticInput/BuildEmissionsSemanticInput so
-      //    errors carry line:col.
+      // Semantic validation — needs a structurally-valid document, so only run it when
+      // the structure is clean.
       if (errors.empty())
       {
-        // Uses the same ValidateReactionsSemantics/ValidateEmissionsSemantics engines as
-        // ValidateGasModel/ValidateEmissionsModel, but with YAML-derived input so errors include
-        // source locations.
-        auto semantic_errors = ValidateReactionsSemantics(BuildSemanticInput(object));
+        auto semantic_errors = ValidateReactionsSemantics(BuildReactionsSemanticInput(object));
+        auto aerosol_errors = ValidateAerosolSemantics(BuildAerosolSemanticInput(object));
         auto emissions_errors = ValidateEmissionsSemantics(BuildEmissionsSemanticInput(object));
+        semantic_errors.insert(semantic_errors.end(), aerosol_errors.begin(), aerosol_errors.end());
         semantic_errors.insert(semantic_errors.end(), emissions_errors.begin(), emissions_errors.end());
         AppendFilePath(config_path_, semantic_errors);
         errors.insert(errors.end(), semantic_errors.begin(), semantic_errors.end());
@@ -463,19 +593,7 @@ namespace mechanism_configuration::v1
         return std::unexpected(std::move(errors));
       }
 
-      // 3) Build the Mechanism (structurally valid; aerosol parsers source values defensively).
-      Mechanism mechanism = Build(object);
-
-      // 4) Aerosol cross-reference validation runs against the built structs (species/phase
-      //    membership and sourced properties such as diffusion coefficient, solvent density).
-      Errors aerosol_errors = ValidateAerosolModel(mechanism);
-      if (!aerosol_errors.empty())
-      {
-        AppendFilePath(config_path_, aerosol_errors);
-        return std::unexpected(std::move(aerosol_errors));
-      }
-
-      return mechanism;
+      return Build(object);
     }
     catch (const std::exception& e)
     {

--- a/src/v1/reactions/arrhenius.cpp
+++ b/src/v1/reactions/arrhenius.cpp
@@ -20,8 +20,8 @@ namespace mechanism_configuration::v1
   ///        Performs schema validation, checks for mutually exclusive parameters (`Ea` vs `C`),
   ///        and collects any structural errors found.
   /// @param object The YAML node representing the reaction
-  /// @param existing_species Unused; semantic checks live in ValidateSemantics
-  /// @param existing_phases Unused; semantic checks live in ValidateSemantics
+  /// @param existing_species Unused; semantic checks live in ValidateReactionsSemantics
+  /// @param existing_phases Unused; semantic checks live in ValidateReactionsSemantics
   /// @return A list of validation errors, if any
   Errors ArrheniusParser::CheckSchema(
       const YAML::Node& object,
@@ -67,7 +67,7 @@ namespace mechanism_configuration::v1
     }
 
     // Semantic checks (species existence, phase membership) are performed by the
-    // version-neutral ValidateSemantics over the canonical Mechanism.
+    // version-neutral ValidateReactionsSemantics over the canonical Mechanism.
     return errors;
   }
 

--- a/src/v1/reactions/branched.cpp
+++ b/src/v1/reactions/branched.cpp
@@ -19,8 +19,8 @@ namespace mechanism_configuration::v1
   ///        Performs structural (schema) validation only;
   ///        and collects any errors found.
   /// @param object The YAML node representing the reaction
-  /// @param existing_species Unused; semantic checks live in ValidateSemantics
-  /// @param existing_phases Unused; semantic checks live in ValidateSemantics
+  /// @param existing_species Unused; semantic checks live in ValidateReactionsSemantics
+  /// @param existing_phases Unused; semantic checks live in ValidateReactionsSemantics
   /// @return A list of validation errors, if any
   Errors BranchedParser::CheckSchema(
       const YAML::Node& object,
@@ -63,7 +63,7 @@ namespace mechanism_configuration::v1
     }
 
     // Semantic checks (species existence, phase membership) are performed by the
-    // version-neutral ValidateSemantics over the canonical Mechanism.
+    // version-neutral ValidateReactionsSemantics over the canonical Mechanism.
     return errors;
   }
 

--- a/src/v1/reactions/emission.cpp
+++ b/src/v1/reactions/emission.cpp
@@ -19,8 +19,8 @@ namespace mechanism_configuration::v1
   ///        Performs structural (schema) validation only;
   ///        and collects any errors found.
   /// @param object The YAML node representing the reaction
-  /// @param existing_species Unused; semantic checks live in ValidateSemantics
-  /// @param existing_phases Unused; semantic checks live in ValidateSemantics
+  /// @param existing_species Unused; semantic checks live in ValidateReactionsSemantics
+  /// @param existing_phases Unused; semantic checks live in ValidateReactionsSemantics
   /// @return A list of validation errors, if any
   Errors EmissionParser::CheckSchema(
       const YAML::Node& object,
@@ -47,7 +47,7 @@ namespace mechanism_configuration::v1
     }
 
     // Semantic checks (species existence, phase membership) are performed by the
-    // version-neutral ValidateSemantics over the canonical Mechanism.
+    // version-neutral ValidateReactionsSemantics over the canonical Mechanism.
     return errors;
   }
 

--- a/src/v1/reactions/first_order_loss.cpp
+++ b/src/v1/reactions/first_order_loss.cpp
@@ -19,8 +19,8 @@ namespace mechanism_configuration::v1
   ///        Performs structural (schema) validation only;
   ///        and collects any errors found.
   /// @param object The YAML node representing the reaction
-  /// @param existing_species Unused; semantic checks live in ValidateSemantics
-  /// @param existing_phases Unused; semantic checks live in ValidateSemantics
+  /// @param existing_species Unused; semantic checks live in ValidateReactionsSemantics
+  /// @param existing_phases Unused; semantic checks live in ValidateReactionsSemantics
   /// @return A list of validation errors, if any
   Errors FirstOrderLossParser::CheckSchema(
       const YAML::Node& object,
@@ -73,7 +73,7 @@ namespace mechanism_configuration::v1
     }
 
     // Semantic checks (species existence, phase membership) are performed by the
-    // version-neutral ValidateSemantics over the canonical Mechanism.
+    // version-neutral ValidateReactionsSemantics over the canonical Mechanism.
     return errors;
   }
 

--- a/src/v1/reactions/lambda_rate_constant.cpp
+++ b/src/v1/reactions/lambda_rate_constant.cpp
@@ -19,8 +19,8 @@ namespace mechanism_configuration::v1
   ///        Performs structural (schema) validation only;
   ///        and collects any errors found.
   /// @param object The YAML node representing the reaction
-  /// @param existing_species Unused; semantic checks live in ValidateSemantics
-  /// @param existing_phases Unused; semantic checks live in ValidateSemantics
+  /// @param existing_species Unused; semantic checks live in ValidateReactionsSemantics
+  /// @param existing_phases Unused; semantic checks live in ValidateReactionsSemantics
   /// @return A list of validation errors, if any
   Errors LambdaRateConstantParser::CheckSchema(
       const YAML::Node& object,
@@ -54,7 +54,7 @@ namespace mechanism_configuration::v1
       errors.insert(errors.end(), schema_errors.begin(), schema_errors.end());
     }
 
-    // Semantic checks are performed by the version-neutral ValidateSemantics.
+    // Semantic checks are performed by the version-neutral ValidateReactionsSemantics.
 
     return errors;
   }

--- a/src/v1/reactions/photolysis.cpp
+++ b/src/v1/reactions/photolysis.cpp
@@ -19,8 +19,8 @@ namespace mechanism_configuration::v1
   ///        Performs structural (schema) validation only;
   ///        and collects any errors found.
   /// @param object The YAML node representing the reaction
-  /// @param existing_species Unused; semantic checks live in ValidateSemantics
-  /// @param existing_phases Unused; semantic checks live in ValidateSemantics
+  /// @param existing_species Unused; semantic checks live in ValidateReactionsSemantics
+  /// @param existing_phases Unused; semantic checks live in ValidateReactionsSemantics
   /// @return A list of validation errors, if any
   Errors PhotolysisParser::CheckSchema(
       const YAML::Node& object,
@@ -83,7 +83,7 @@ namespace mechanism_configuration::v1
     }
 
     // Semantic checks (species existence, phase membership) are performed by the
-    // version-neutral ValidateSemantics over the canonical Mechanism.
+    // version-neutral ValidateReactionsSemantics over the canonical Mechanism.
     return errors;
   }
 

--- a/src/v1/reactions/surface.cpp
+++ b/src/v1/reactions/surface.cpp
@@ -19,8 +19,8 @@ namespace mechanism_configuration::v1
   ///        Performs structural (schema) validation only;
   ///        and collects any errors found.
   /// @param object The YAML node representing the reaction
-  /// @param existing_species Unused; semantic checks live in ValidateSemantics
-  /// @param existing_phases Unused; semantic checks live in ValidateSemantics
+  /// @param existing_species Unused; semantic checks live in ValidateReactionsSemantics
+  /// @param existing_phases Unused; semantic checks live in ValidateReactionsSemantics
   /// @return A list of validation errors, if any
   Errors SurfaceParser::CheckSchema(
       const YAML::Node& object,
@@ -85,7 +85,7 @@ namespace mechanism_configuration::v1
     }
 
     // Semantic checks (species existence, phase membership) are performed by the
-    // version-neutral ValidateSemantics over the canonical Mechanism.
+    // version-neutral ValidateReactionsSemantics over the canonical Mechanism.
     return errors;
   }
   void SurfaceParser::Parse(const YAML::Node& object, types::Reactions& reactions)

--- a/src/v1/reactions/taylor_series.cpp
+++ b/src/v1/reactions/taylor_series.cpp
@@ -20,8 +20,8 @@ namespace mechanism_configuration::v1
   ///        Performs schema validation, checks for mutually exclusive parameters (`Ea` vs `C`),
   ///        and collects any structural errors found.
   /// @param object The YAML node representing the reaction
-  /// @param existing_species Unused; semantic checks live in ValidateSemantics
-  /// @param existing_phases Unused; semantic checks live in ValidateSemantics
+  /// @param existing_species Unused; semantic checks live in ValidateReactionsSemantics
+  /// @param existing_phases Unused; semantic checks live in ValidateReactionsSemantics
   /// @return A list of validation errors, if any
   Errors TaylorSeriesParser::CheckSchema(
       const YAML::Node& object,
@@ -67,7 +67,7 @@ namespace mechanism_configuration::v1
       errors.push_back({ ErrorCode::MutuallyExclusiveOption, message });
     }
 
-    // Semantic checks are performed by the version-neutral ValidateSemantics.
+    // Semantic checks are performed by the version-neutral ValidateReactionsSemantics.
 
     return errors;
   }

--- a/src/v1/reactions/ternary_chemical_activation.cpp
+++ b/src/v1/reactions/ternary_chemical_activation.cpp
@@ -18,8 +18,8 @@ namespace mechanism_configuration::v1
   ///        Performs structural (schema) validation only;
   ///        and collects any errors found.
   /// @param object The YAML node representing the reaction
-  /// @param existing_species Unused; semantic checks live in ValidateSemantics
-  /// @param existing_phases Unused; semantic checks live in ValidateSemantics
+  /// @param existing_species Unused; semantic checks live in ValidateReactionsSemantics
+  /// @param existing_phases Unused; semantic checks live in ValidateReactionsSemantics
   /// @return A list of validation errors, if any
   Errors TernaryChemicalActivationParser::CheckSchema(
       const YAML::Node& object,
@@ -52,7 +52,7 @@ namespace mechanism_configuration::v1
       errors.insert(errors.end(), schema_errors.begin(), schema_errors.end());
     }
 
-    // Semantic checks are performed by the version-neutral ValidateSemantics.
+    // Semantic checks are performed by the version-neutral ValidateReactionsSemantics.
 
     return errors;
   }

--- a/src/v1/reactions/troe.cpp
+++ b/src/v1/reactions/troe.cpp
@@ -18,8 +18,8 @@ namespace mechanism_configuration::v1
   ///        Performs structural (schema) validation only;
   ///        and collects any errors found.
   /// @param object The YAML node representing the reaction
-  /// @param existing_species Unused; semantic checks live in ValidateSemantics
-  /// @param existing_phases Unused; semantic checks live in ValidateSemantics
+  /// @param existing_species Unused; semantic checks live in ValidateReactionsSemantics
+  /// @param existing_phases Unused; semantic checks live in ValidateReactionsSemantics
   /// @return A list of validation errors, if any
   Errors TroeParser::CheckSchema(
       const YAML::Node& object,
@@ -52,7 +52,7 @@ namespace mechanism_configuration::v1
       errors.insert(errors.end(), schema_errors.begin(), schema_errors.end());
     }
 
-    // Semantic checks are performed by the version-neutral ValidateSemantics.
+    // Semantic checks are performed by the version-neutral ValidateReactionsSemantics.
 
     return errors;
   }

--- a/src/v1/reactions/tunneling.cpp
+++ b/src/v1/reactions/tunneling.cpp
@@ -18,8 +18,8 @@ namespace mechanism_configuration::v1
   ///        Performs structural (schema) validation only;
   ///        and collects any errors found.
   /// @param object The YAML node representing the reaction
-  /// @param existing_species Unused; semantic checks live in ValidateSemantics
-  /// @param existing_phases Unused; semantic checks live in ValidateSemantics
+  /// @param existing_species Unused; semantic checks live in ValidateReactionsSemantics
+  /// @param existing_phases Unused; semantic checks live in ValidateReactionsSemantics
   /// @return A list of validation errors, if any
   Errors TunnelingParser::CheckSchema(
       const YAML::Node& object,
@@ -52,7 +52,7 @@ namespace mechanism_configuration::v1
       errors.insert(errors.end(), schema_errors.begin(), schema_errors.end());
     }
 
-    // Semantic checks are performed by the version-neutral ValidateSemantics.
+    // Semantic checks are performed by the version-neutral ValidateReactionsSemantics.
 
     return errors;
   }

--- a/src/v1/reactions/user_defined.cpp
+++ b/src/v1/reactions/user_defined.cpp
@@ -19,8 +19,8 @@ namespace mechanism_configuration::v1
   ///        Performs structural (schema) validation only;
   ///        and collects any errors found.
   /// @param object The YAML node representing the reaction
-  /// @param existing_species Unused; semantic checks live in ValidateSemantics
-  /// @param existing_phases Unused; semantic checks live in ValidateSemantics
+  /// @param existing_species Unused; semantic checks live in ValidateReactionsSemantics
+  /// @param existing_phases Unused; semantic checks live in ValidateReactionsSemantics
   /// @return A list of validation errors, if any
   Errors UserDefinedParser::CheckSchema(
       const YAML::Node& object,
@@ -53,7 +53,7 @@ namespace mechanism_configuration::v1
       errors.insert(errors.end(), schema_errors.begin(), schema_errors.end());
     }
 
-    // Semantic checks are performed by the version-neutral ValidateSemantics.
+    // Semantic checks are performed by the version-neutral ValidateReactionsSemantics.
 
     return errors;
   }

--- a/src/v1/species/schema.cpp
+++ b/src/v1/species/schema.cpp
@@ -32,7 +32,7 @@ namespace mechanism_configuration::v1
                                                           keys::constant_mixing_ratio,
                                                           keys::is_third_body };
     // Structural validation only. Duplicate-species detection (a semantic check) is performed
-    // by the version-neutral ValidateSemantics.
+    // by the version-neutral ValidateReactionsSemantics.
     Errors errors;
     for (const auto& object : species_list)
     {
@@ -53,7 +53,7 @@ namespace mechanism_configuration::v1
 
     // Structural validation only. Duplicate detection, phase-species existence, and
     // phase-membership (semantic checks) are performed by the version-neutral
-    // ValidateSemantics. existing_species is intentionally unused here.
+    // ValidateReactionsSemantics. existing_species is intentionally unused here.
     (void)existing_species;
     Errors errors;
     for (const auto& object : AsSequence(phases_list))

--- a/src/validate.cpp
+++ b/src/validate.cpp
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "detail/error_format.hpp"
-#include "detail/semantics/reactions.hpp"
+#include "detail/semantics/aerosol.hpp"
 #include "detail/semantics/emissions.hpp"
+#include "detail/semantics/reactions.hpp"
 
 #include <mechanism_configuration/validate.hpp>
 
@@ -113,6 +114,165 @@ namespace mechanism_configuration
                     product.location,
                     mc_fmt::format("Unknown species '{}' used in '{}' reaction.", product.name, reaction.type)) });
       }
+    }
+
+    return errors;
+  }
+
+  Errors ValidateAerosolSemantics(const semantics::AerosolInput& input)
+  {
+    Errors errors;
+
+    if (input.representations.empty() && input.dissolved_reactions.empty() &&
+        input.dissolved_reversible_reactions.empty() && input.henrys_law_phase_transfers.empty() &&
+        input.henrys_law_equilibria.empty() && input.dissolved_equilibria.empty() &&
+        input.linear_constraints.empty())
+      return errors;
+
+    // Index species for molecular weight.
+    std::unordered_map<std::string, const semantics::SpeciesDef*> species_index;
+    for (const auto& s : input.species)
+      species_index.emplace(s.name, &s);
+
+    // Index phase-species for membership, diffusion, density.
+    std::unordered_map<std::string, std::unordered_map<std::string, const semantics::PhaseSpeciesDef*>> phase_index;
+    for (const auto& phase : input.phases)
+    {
+      auto& registered = phase_index[phase.name];
+      for (const auto& ps : phase.species)
+        registered.emplace(ps.name, &ps);
+    }
+
+    // Verifies that species is registered in phase. Returns the entry (or nullptr) and reports.
+    auto require_registered_species = [&](const semantics::NamedRef& phase,
+                                           const semantics::NamedRef& species,
+                                           const std::string& context) -> const semantics::PhaseSpeciesDef*
+    {
+      const auto phase_it = phase_index.find(phase.name);
+      if (phase_it == phase_index.end())
+      {
+        errors.push_back(
+            { ErrorCode::UnknownPhase,
+              Message(phase.location, mc_fmt::format("Unknown phase '{}' referenced by {}.", phase.name, context)) });
+        return nullptr;
+      }
+      const auto species_it = phase_it->second.find(species.name);
+      if (species_it == phase_it->second.end())
+      {
+        errors.push_back(
+            { ErrorCode::RequestedSpeciesNotRegisteredInPhase,
+              Message(
+                  species.location,
+                  mc_fmt::format("Species '{}' ({}) is not defined in the '{}' phase.", species.name, context, phase.name)) });
+        return nullptr;
+      }
+      return species_it->second;
+    };
+
+    auto require_diffusion =
+        [&](const semantics::NamedRef& phase, const semantics::NamedRef& species, const std::string& context)
+    {
+      const auto* entry = require_registered_species(phase, species, context);
+      if (entry && !entry->has_diffusion_coefficient)
+        errors.push_back({ ErrorCode::RequiredKeyNotFound,
+                           Message(
+                               species.location,
+                               mc_fmt::format(
+                                   "{}: species '{}' has no diffusion coefficient defined in "
+                                   "the '{}' phase.",
+                                   context,
+                                   species.name,
+                                   phase.name)) });
+    };
+
+    auto require_density =
+        [&](const semantics::NamedRef& phase, const semantics::NamedRef& species, const std::string& context)
+    {
+      const auto* entry = require_registered_species(phase, species, context);
+      if (entry && !entry->has_density)
+        errors.push_back(
+            { ErrorCode::RequiredKeyNotFound,
+              Message(
+                  species.location,
+                  mc_fmt::format("{}: species '{}' has no density defined in the '{}' phase.", context, species.name, phase.name)) });
+    };
+
+    auto require_molecular_weight = [&](const semantics::NamedRef& species, const std::string& context)
+    {
+      const auto species_it = species_index.find(species.name);
+      if (species_it == species_index.end())
+        errors.push_back(
+            { ErrorCode::UnknownSpecies,
+              Message(species.location, mc_fmt::format("Unknown species '{}' referenced by {}.", species.name, context)) });
+      else if (!species_it->second->has_molecular_weight)
+        errors.push_back(
+            { ErrorCode::RequiredKeyNotFound,
+              Message(
+                  species.location,
+                  mc_fmt::format("{}: species '{}' has no molecular weight defined.", context, species.name)) });
+    };
+
+    // Verifies that phase exists.
+    auto require_phase = [&](const semantics::NamedRef& phase, const std::string& context)
+    {
+      if (!phase_index.contains(phase.name))
+        errors.push_back(
+            { ErrorCode::UnknownPhase,
+              Message(phase.location, mc_fmt::format("Unknown phase '{}' referenced by {}.", phase.name, context)) });
+    };
+
+    for (const auto& representation : input.representations)
+      for (const auto& phase : representation.phases)
+        require_phase(phase, mc_fmt::format("aerosol representation '{}'", representation.name));
+
+    for (const auto& p : input.dissolved_reactions)
+    {
+      for (const auto& c : p.reactants)
+        require_registered_species(p.phase, c, "DISSOLVED_REACTION reactant");
+      for (const auto& c : p.products)
+        require_registered_species(p.phase, c, "DISSOLVED_REACTION product");
+      require_registered_species(p.phase, p.solvent, "DISSOLVED_REACTION solvent");
+    }
+
+    for (const auto& p : input.dissolved_reversible_reactions)
+    {
+      for (const auto& c : p.reactants)
+        require_registered_species(p.phase, c, "DISSOLVED_REVERSIBLE_REACTION reactant");
+      for (const auto& c : p.products)
+        require_registered_species(p.phase, c, "DISSOLVED_REVERSIBLE_REACTION product");
+      require_registered_species(p.phase, p.solvent, "DISSOLVED_REVERSIBLE_REACTION solvent");
+    }
+
+    for (const auto& p : input.henrys_law_phase_transfers)
+    {
+      require_registered_species(p.condensed_phase, p.condensed_species, "HENRYS_LAW_PHASE_TRANSFER condensed species");
+      require_registered_species(p.condensed_phase, p.solvent, "HENRYS_LAW_PHASE_TRANSFER solvent");
+      require_diffusion(p.gas_phase, p.gas_species, "HENRYS_LAW_PHASE_TRANSFER");
+    }
+
+    for (const auto& c : input.henrys_law_equilibria)
+    {
+      require_registered_species(c.gas_phase, c.gas_species, "HENRYS_LAW_EQUILIBRIUM gas species");
+      require_registered_species(c.condensed_phase, c.condensed_species, "HENRYS_LAW_EQUILIBRIUM condensed species");
+      require_density(c.condensed_phase, c.solvent, "HENRYS_LAW_EQUILIBRIUM solvent");
+      require_molecular_weight(c.solvent, "HENRYS_LAW_EQUILIBRIUM solvent");
+    }
+
+    for (const auto& c : input.dissolved_equilibria)
+    {
+      require_registered_species(c.phase, c.algebraic_species, "DISSOLVED_EQUILIBRIUM algebraic species");
+      require_registered_species(c.phase, c.solvent, "DISSOLVED_EQUILIBRIUM solvent");
+      for (const auto& x : c.reactants)
+        require_registered_species(c.phase, x, "DISSOLVED_EQUILIBRIUM reactant");
+      for (const auto& x : c.products)
+        require_registered_species(c.phase, x, "DISSOLVED_EQUILIBRIUM product");
+    }
+
+    for (const auto& c : input.linear_constraints)
+    {
+      require_registered_species(c.algebraic_phase, c.algebraic_species, "LINEAR_CONSTRAINT algebraic species");
+      for (const auto& t : c.terms)
+        require_registered_species(t.phase, t.species, "LINEAR_CONSTRAINT term");
     }
 
     return errors;
@@ -282,108 +442,35 @@ namespace mechanism_configuration
 
   Errors ValidateAerosolModel(const Mechanism& mechanism)
   {
-    Errors errors;
-
     if (!mechanism.aerosol)
-      return errors;
+      return {};
 
-    const auto& aerosol = *mechanism.aerosol;
-    if (aerosol.representations.empty() && aerosol.processes.empty() && aerosol.constraints.empty())
-      return errors;
+    semantics::AerosolInput input;
 
-    // Index species for molecular weight.
-    std::unordered_map<std::string, const types::Species*> species_index;
     for (const auto& s : mechanism.species)
-      species_index.emplace(s.name, &s);
+      input.species.push_back({ s.name, s.molecular_weight.has_value() });
 
-    // Index phase-species for membership, diffusion, density.
-    std::unordered_map<std::string, std::unordered_map<std::string, const types::PhaseSpecies*>> phase_index;
     for (const auto& phase : mechanism.phases)
     {
-      auto& registered = phase_index[phase.name];
+      semantics::PhaseDef phase_def;
+      phase_def.name = phase.name;
       for (const auto& ps : phase.species)
-        registered.emplace(ps.name, &ps);
+        phase_def.species.push_back({ ps.name, ps.diffusion_coefficient.has_value(), ps.density.has_value() });
+      input.phases.push_back(std::move(phase_def));
     }
 
-    // Verifies that species is registered in phase. Returns the entry (or nullptr) and reports.
-    auto require_registered_species =
-        [&](const std::string& phase, const std::string& species, const std::string& context) -> const types::PhaseSpecies*
-    {
-      const auto phase_it = phase_index.find(phase);
-      if (phase_it == phase_index.end())
-      {
-        errors.push_back({ ErrorCode::UnknownPhase,
-                           Message(std::nullopt, mc_fmt::format("Unknown phase '{}' referenced by {}.", phase, context)) });
-        return nullptr;
-      }
-      const auto species_it = phase_it->second.find(species);
-      if (species_it == phase_it->second.end())
-      {
-        errors.push_back(
-            { ErrorCode::RequestedSpeciesNotRegisteredInPhase,
-              Message(
-                  std::nullopt,
-                  mc_fmt::format("Species '{}' ({}) is not defined in the '{}' phase.", species, context, phase)) });
-        return nullptr;
-      }
-      return species_it->second;
-    };
-
-    auto require_diffusion = [&](const std::string& phase, const std::string& species, const std::string& context)
-    {
-      const auto* entry = require_registered_species(phase, species, context);
-      if (entry && !entry->diffusion_coefficient)
-        errors.push_back({ ErrorCode::RequiredKeyNotFound,
-                           Message(
-                               std::nullopt,
-                               mc_fmt::format(
-                                   "{}: species '{}' has no diffusion coefficient defined in "
-                                   "the '{}' phase.",
-                                   context,
-                                   species,
-                                   phase)) });
-    };
-
-    auto require_density = [&](const std::string& phase, const std::string& species, const std::string& context)
-    {
-      const auto* entry = require_registered_species(phase, species, context);
-      if (entry && !entry->density)
-        errors.push_back(
-            { ErrorCode::RequiredKeyNotFound,
-              Message(
-                  std::nullopt,
-                  mc_fmt::format("{}: species '{}' has no density defined in the '{}' phase.", context, species, phase)) });
-    };
-
-    auto require_molecular_weight = [&](const std::string& species, const std::string& context)
-    {
-      const auto species_it = species_index.find(species);
-      if (species_it == species_index.end())
-        errors.push_back(
-            { ErrorCode::UnknownSpecies,
-              Message(std::nullopt, mc_fmt::format("Unknown species '{}' referenced by {}.", species, context)) });
-      else if (!species_it->second->molecular_weight)
-        errors.push_back(
-            { ErrorCode::RequiredKeyNotFound,
-              Message(
-                  std::nullopt, mc_fmt::format("{}: species '{}' has no molecular weight defined.", context, species)) });
-    };
-
-    // Verifies that phase exists.
-    auto require_phase = [&](const std::string& phase, const std::string& context)
-    {
-      if (!phase_index.contains(phase))
-        errors.push_back({ ErrorCode::UnknownPhase,
-                           Message(std::nullopt, mc_fmt::format("Unknown phase '{}' referenced by {}.", phase, context)) });
-    };
+    const auto& aerosol = *mechanism.aerosol;
 
     for (const auto& representation : aerosol.representations)
     {
       std::visit(
           [&](const auto& rep)
           {
+            semantics::AerosolRepresentationRef ref;
+            ref.name = rep.name;
             for (const auto& phase : rep.phases)
-              require_phase(phase, mc_fmt::format("aerosol representation '{}'", rep.name));
+              ref.phases.push_back({ phase, std::nullopt });
+            input.representations.push_back(std::move(ref));
           },
           representation);
     }
@@ -392,25 +479,31 @@ namespace mechanism_configuration
     {
       if (const auto* p = std::get_if<types::DissolvedReaction>(&process))
       {
-        for (const auto& c : p->reactants)
-          require_registered_species(p->phase, c.name, "DISSOLVED_REACTION reactant");
-        for (const auto& c : p->products)
-          require_registered_species(p->phase, c.name, "DISSOLVED_REACTION product");
-        require_registered_species(p->phase, p->solvent, "DISSOLVED_REACTION solvent");
+        semantics::DissolvedReactionRef ref;
+        ref.phase = { p->phase, std::nullopt };
+        ref.solvent = { p->solvent, std::nullopt };
+        ref.reactants = Refs(p->reactants);
+        ref.products = Refs(p->products);
+        input.dissolved_reactions.push_back(std::move(ref));
       }
       else if (const auto* p = std::get_if<types::DissolvedReversibleReaction>(&process))
       {
-        for (const auto& c : p->reactants)
-          require_registered_species(p->phase, c.name, "DISSOLVED_REVERSIBLE_REACTION reactant");
-        for (const auto& c : p->products)
-          require_registered_species(p->phase, c.name, "DISSOLVED_REVERSIBLE_REACTION product");
-        require_registered_species(p->phase, p->solvent, "DISSOLVED_REVERSIBLE_REACTION solvent");
+        semantics::DissolvedReversibleReactionRef ref;
+        ref.phase = { p->phase, std::nullopt };
+        ref.solvent = { p->solvent, std::nullopt };
+        ref.reactants = Refs(p->reactants);
+        ref.products = Refs(p->products);
+        input.dissolved_reversible_reactions.push_back(std::move(ref));
       }
       else if (const auto* p = std::get_if<types::HenrysLawPhaseTransfer>(&process))
       {
-        require_registered_species(p->condensed_phase, p->condensed_species, "HENRYS_LAW_PHASE_TRANSFER condensed species");
-        require_registered_species(p->condensed_phase, p->solvent, "HENRYS_LAW_PHASE_TRANSFER solvent");
-        require_diffusion(p->gas_phase, p->gas_species, "HENRYS_LAW_PHASE_TRANSFER");
+        semantics::HenrysLawPhaseTransferRef ref;
+        ref.gas_phase = { p->gas_phase, std::nullopt };
+        ref.gas_species = { p->gas_species, std::nullopt };
+        ref.condensed_phase = { p->condensed_phase, std::nullopt };
+        ref.condensed_species = { p->condensed_species, std::nullopt };
+        ref.solvent = { p->solvent, std::nullopt };
+        input.henrys_law_phase_transfers.push_back(std::move(ref));
       }
     }
 
@@ -418,29 +511,36 @@ namespace mechanism_configuration
     {
       if (const auto* c = std::get_if<types::HenrysLawEquilibrium>(&constraint))
       {
-        require_registered_species(c->gas_phase, c->gas_species, "HENRYS_LAW_EQUILIBRIUM gas species");
-        require_registered_species(c->condensed_phase, c->condensed_species, "HENRYS_LAW_EQUILIBRIUM condensed species");
-        require_density(c->condensed_phase, c->solvent, "HENRYS_LAW_EQUILIBRIUM solvent");
-        require_molecular_weight(c->solvent, "HENRYS_LAW_EQUILIBRIUM solvent");
+        semantics::HenrysLawEquilibriumRef ref;
+        ref.gas_phase = { c->gas_phase, std::nullopt };
+        ref.gas_species = { c->gas_species, std::nullopt };
+        ref.condensed_phase = { c->condensed_phase, std::nullopt };
+        ref.condensed_species = { c->condensed_species, std::nullopt };
+        ref.solvent = { c->solvent, std::nullopt };
+        input.henrys_law_equilibria.push_back(std::move(ref));
       }
       else if (const auto* c = std::get_if<types::DissolvedEquilibrium>(&constraint))
       {
-        require_registered_species(c->phase, c->algebraic_species, "DISSOLVED_EQUILIBRIUM algebraic species");
-        require_registered_species(c->phase, c->solvent, "DISSOLVED_EQUILIBRIUM solvent");
-        for (const auto& x : c->reactants)
-          require_registered_species(c->phase, x.name, "DISSOLVED_EQUILIBRIUM reactant");
-        for (const auto& x : c->products)
-          require_registered_species(c->phase, x.name, "DISSOLVED_EQUILIBRIUM product");
+        semantics::DissolvedEquilibriumRef ref;
+        ref.phase = { c->phase, std::nullopt };
+        ref.algebraic_species = { c->algebraic_species, std::nullopt };
+        ref.solvent = { c->solvent, std::nullopt };
+        ref.reactants = Refs(c->reactants);
+        ref.products = Refs(c->products);
+        input.dissolved_equilibria.push_back(std::move(ref));
       }
       else if (const auto* c = std::get_if<types::LinearConstraint>(&constraint))
       {
-        require_registered_species(c->algebraic_phase, c->algebraic_species, "LINEAR_CONSTRAINT algebraic species");
+        semantics::LinearConstraintRef ref;
+        ref.algebraic_phase = { c->algebraic_phase, std::nullopt };
+        ref.algebraic_species = { c->algebraic_species, std::nullopt };
         for (const auto& t : c->terms)
-          require_registered_species(t.phase, t.name, "LINEAR_CONSTRAINT term");
+          ref.terms.push_back({ { t.phase, std::nullopt }, { t.name, std::nullopt } });
+        input.linear_constraints.push_back(std::move(ref));
       }
     }
 
-    return errors;
+    return ValidateAerosolSemantics(input);
   }
 
   Errors ValidateEmissionsModel(const Mechanism& mechanism)

--- a/src/validate.cpp
+++ b/src/validate.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "detail/error_format.hpp"
+#include "detail/semantics/reactions.hpp"
+#include "detail/semantics/emissions.hpp"
 
 #include <mechanism_configuration/validate.hpp>
 
@@ -43,7 +45,7 @@ namespace mechanism_configuration
     }
   }  // namespace
 
-  Errors ValidateSemantics(const semantics::Input& input)
+  Errors ValidateReactionsSemantics(const semantics::ReactionsInput& input)
   {
     Errors errors;
 
@@ -113,88 +115,89 @@ namespace mechanism_configuration
       }
     }
 
-    // ---- Emissions ----------------------------------------------------------------------------
-    if (input.emissions)
+    return errors;
+  }
+
+  Errors ValidateEmissionsSemantics(const semantics::EmissionsInput& input)
+  {
+    Errors errors;
+
+    ReportDuplicates(input.inventories, ErrorCode::DuplicateInventoryDetected, "inventory", errors);
+
+    std::vector<semantics::NamedRef> species_map_names;
+    for (const auto& smap : input.species_maps)
+      species_map_names.push_back({ smap.name, smap.location });
+    ReportDuplicates(species_map_names, ErrorCode::DuplicateSpeciesMapDetected, "species map", errors);
+
+    std::vector<semantics::NamedRef> source_names;
+    for (const auto& source : input.sources)
+      source_names.push_back({ source.name, source.location });
+    ReportDuplicates(source_names, ErrorCode::DuplicateSourceDetected, "source", errors);
+
+    std::unordered_set<std::string> inventory_names;
+    for (const auto& inv : input.inventories)
+      inventory_names.insert(inv.name);
+
+    std::unordered_set<std::string> species_map_name_set;
+    for (const auto& smap : input.species_maps)
+      species_map_name_set.insert(smap.name);
+
+    std::map<std::pair<int, int>, int> cat_hier_counts;
+    for (const auto& source : input.sources)
+      ++cat_hier_counts[{ source.category, source.hierarchy }];
+
+    for (const auto& source : input.sources)
     {
-      const auto& emissions = *input.emissions;
+      if (!inventory_names.contains(source.inventory.name))
+        errors.push_back({ ErrorCode::SourceRequiresUnknownInventory,
+                           Message(
+                               source.inventory.location,
+                               mc_fmt::format(
+                                   "Source '{}' references inventory '{}' which is not declared in 'inventories'.",
+                                   source.name,
+                                   source.inventory.name)) });
 
-      ReportDuplicates(emissions.inventories, ErrorCode::DuplicateInventoryDetected, "inventory", errors);
+      if (!species_map_name_set.contains(source.species_map.name))
+        errors.push_back({ ErrorCode::SourceRequiresUnknownSpeciesMap,
+                           Message(
+                               source.species_map.location,
+                               mc_fmt::format(
+                                   "Source '{}' references species map '{}' which is not declared in 'species maps'.",
+                                   source.name,
+                                   source.species_map.name)) });
 
-      std::vector<semantics::NamedRef> species_map_names;
-      for (const auto& smap : emissions.species_maps)
-        species_map_names.push_back({ smap.name, smap.location });
-      ReportDuplicates(species_map_names, ErrorCode::DuplicateSpeciesMapDetected, "species map", errors);
+      if (cat_hier_counts[{ source.category, source.hierarchy }] > 1)
+        errors.push_back(
+            { ErrorCode::DuplicateCategoryHierarchy,
+              Message(
+                  source.location,
+                  mc_fmt::format(
+                      "Source '{}' has duplicate (category: {}, hierarchy: {}) — each (category, hierarchy) pair "
+                      "must be unique.",
+                      source.name,
+                      source.category,
+                      source.hierarchy)) });
+    }
 
-      std::vector<semantics::NamedRef> source_names;
-      for (const auto& source : emissions.sources)
-        source_names.push_back({ source.name, source.location });
-      ReportDuplicates(source_names, ErrorCode::DuplicateSourceDetected, "source", errors);
+    for (const auto& smap : input.species_maps)
+    {
+      std::unordered_map<std::string, double> scale_sum;
+      for (const auto& mapping : smap.mappings)
+        scale_sum[mapping.inventory_species] += mapping.scaling_factor;
 
-      std::unordered_set<std::string> inventory_names;
-      for (const auto& inv : emissions.inventories)
-        inventory_names.insert(inv.name);
-
-      std::unordered_set<std::string> species_map_name_set;
-      for (const auto& smap : emissions.species_maps)
-        species_map_name_set.insert(smap.name);
-
-      std::map<std::pair<int, int>, int> cat_hier_counts;
-      for (const auto& source : emissions.sources)
-        ++cat_hier_counts[{ source.category, source.hierarchy }];
-
-      for (const auto& source : emissions.sources)
+      for (const auto& [inventory_species, total] : scale_sum)
       {
-        if (!inventory_names.contains(source.inventory.name))
-          errors.push_back({ ErrorCode::SourceRequiresUnknownInventory,
-                             Message(
-                                 source.inventory.location,
-                                 mc_fmt::format(
-                                     "Source '{}' references inventory '{}' which is not declared in 'inventories'.",
-                                     source.name,
-                                     source.inventory.name)) });
-
-        if (!species_map_name_set.contains(source.species_map.name))
-          errors.push_back({ ErrorCode::SourceRequiresUnknownSpeciesMap,
-                             Message(
-                                 source.species_map.location,
-                                 mc_fmt::format(
-                                     "Source '{}' references species map '{}' which is not declared in 'species maps'.",
-                                     source.name,
-                                     source.species_map.name)) });
-
-        if (cat_hier_counts[{ source.category, source.hierarchy }] > 1)
+        if (total > 1.0 + 1e-9)
           errors.push_back(
-              { ErrorCode::DuplicateCategoryHierarchy,
+              { ErrorCode::SpeciesMapScalingExceedsOne,
                 Message(
-                    source.location,
+                    smap.location,
                     mc_fmt::format(
-                        "Source '{}' has duplicate (category: {}, hierarchy: {}) — each (category, hierarchy) pair "
-                        "must be unique.",
-                        source.name,
-                        source.category,
-                        source.hierarchy)) });
-      }
-
-      for (const auto& smap : emissions.species_maps)
-      {
-        std::unordered_map<std::string, double> scale_sum;
-        for (const auto& mapping : smap.mappings)
-          scale_sum[mapping.inventory_species] += mapping.scaling_factor;
-
-        for (const auto& [inventory_species, total] : scale_sum)
-        {
-          if (total > 1.0 + 1e-9)
-            errors.push_back(
-                { ErrorCode::SpeciesMapScalingExceedsOne,
-                  Message(
-                      smap.location,
-                      mc_fmt::format(
-                          "Species map '{}': scaling factors for inventory species '{}' sum to {:.4f}, which exceeds "
-                          "1.0.",
-                          smap.name,
-                          inventory_species,
-                          total)) });
-        }
+                        "Species map '{}': scaling factors for inventory species '{}' sum to {:.4f}, which exceeds "
+                        "1.0.",
+                        smap.name,
+                        inventory_species,
+                        total)) });
       }
     }
 
@@ -225,7 +228,7 @@ namespace mechanism_configuration
 
   Errors ValidateGasModel(const Mechanism& mechanism)
   {
-    semantics::Input input;
+    semantics::ReactionsInput input;
 
     for (const auto& s : mechanism.species)
       input.species.push_back({ s.name, std::nullopt });
@@ -274,7 +277,7 @@ namespace mechanism_configuration
       add("BRANCHED", x.gas_phase, Refs(x.reactants), Refs(products));
     }
 
-    return ValidateSemantics(input);
+    return ValidateReactionsSemantics(input);
   }
 
   Errors ValidateAerosolModel(const Mechanism& mechanism)
@@ -445,11 +448,10 @@ namespace mechanism_configuration
     if (!mechanism.emissions)
       return {};
 
-    semantics::Input input;
-    semantics::EmissionsRef emissions_ref;
+    semantics::EmissionsInput input;
 
     for (const auto& inv : mechanism.emissions->inventories)
-      emissions_ref.inventories.push_back({ inv.name, std::nullopt });
+      input.inventories.push_back({ inv.name, std::nullopt });
 
     for (const auto& smap : mechanism.emissions->species_maps)
     {
@@ -457,7 +459,7 @@ namespace mechanism_configuration
       smap_ref.name = smap.name;
       for (const auto& mapping : smap.mappings)
         smap_ref.mappings.push_back({ mapping.inventory_species, mapping.mechanism_species, mapping.scaling_factor });
-      emissions_ref.species_maps.push_back(std::move(smap_ref));
+      input.species_maps.push_back(std::move(smap_ref));
     }
 
     for (const auto& source : mechanism.emissions->sources)
@@ -468,12 +470,10 @@ namespace mechanism_configuration
       source_ref.species_map = { source.species_map, std::nullopt };
       source_ref.category = source.category;
       source_ref.hierarchy = source.hierarchy;
-      emissions_ref.sources.push_back(std::move(source_ref));
+      input.sources.push_back(std::move(source_ref));
     }
 
-    input.emissions = std::move(emissions_ref);
-
-    return ValidateSemantics(input);
+    return ValidateEmissionsSemantics(input);
   }
 
   Errors Validate(const Mechanism& mechanism)

--- a/test/unit/v1/test_parse_aerosol.cpp
+++ b/test/unit/v1/test_parse_aerosol.cpp
@@ -108,7 +108,7 @@ TEST(ParseAerosol, RejectsHenrysLawEquilibriumWhenSolventHasNoDensity)
   EXPECT_FALSE(parsed);
   ASSERT_FALSE(parsed) << "Expected validation to fail for a missing solvent density.";
   EXPECT_TRUE(HasError(parsed.error(), ErrorCode::RequiredKeyNotFound));
-  // The location should point at the solvent reference (line 31), not just anywhere.
+  // Location points at the solvent (line 31).
   EXPECT_TRUE(HasErrorAt(parsed.error(), ErrorCode::RequiredKeyNotFound, "31:18"));
 }
 
@@ -116,7 +116,7 @@ TEST(ParseAerosol, RejectsRepresentationReferencingUnknownPhase)
 {
   auto parsed = Parse("v1_unit_configs/aerosol/representation_unknown_phase.json");
   ASSERT_FALSE(parsed) << "Expected validation to fail for a representation referencing an unknown phase.";
-  // Location points at the offending phase name inside the representation's "phases" list (line 14).
+  // Location points at the phase name inside the representation's "phases" list (line 14).
   EXPECT_TRUE(HasErrorAt(parsed.error(), ErrorCode::UnknownPhase, "14:18"));
 }
 
@@ -124,7 +124,7 @@ TEST(ParseAerosol, RejectsDissolvedReactionReferencingUnknownPhase)
 {
   auto parsed = Parse("v1_unit_configs/aerosol/dissolved_reaction_unknown_phase.json");
   ASSERT_FALSE(parsed) << "Expected validation to fail for a dissolved reaction referencing an unknown phase.";
-  // Location points at the "condensed phase" value (line 22), reused for reactant/product/solvent checks.
+  // Location points at the "condensed phase" value (line 22).
   EXPECT_TRUE(HasErrorAt(parsed.error(), ErrorCode::UnknownPhase, "22:26"));
 }
 
@@ -132,7 +132,7 @@ TEST(ParseAerosol, RejectsDissolvedReactionReactantNotRegisteredInPhase)
 {
   auto parsed = Parse("v1_unit_configs/aerosol/dissolved_reaction_reactant_not_in_phase.json");
   ASSERT_FALSE(parsed) << "Expected validation to fail for a reactant not registered in the reaction's phase.";
-  // Location points at the reactant entry itself (line 25), not the phase or the reaction as a whole.
+  // Location points at the reactant entry itself (line 25).
   EXPECT_TRUE(HasErrorAt(parsed.error(), ErrorCode::RequestedSpeciesNotRegisteredInPhase, "25:22"));
 }
 

--- a/test/unit/v1/test_parse_aerosol.cpp
+++ b/test/unit/v1/test_parse_aerosol.cpp
@@ -25,6 +25,17 @@ namespace
     }
     return false;
   }
+
+  bool HasErrorAt(const Errors& errors, ErrorCode code, const std::string& location)
+  {
+    for (const auto& [error_code, message] : errors)
+    {
+      std::cout << message << " " << ErrorCodeToString(error_code) << std::endl;
+      if (error_code == code && message.find(location + " error:") != std::string::npos)
+        return true;
+    }
+    return false;
+  }
 }  // namespace
 
 TEST(ParseAerosol, ParsesValidAerosolConfiguration)
@@ -87,6 +98,8 @@ TEST(ParseAerosol, RejectsPhaseTransferWhenGasSpeciesHasNoDiffusionCoefficient)
   EXPECT_FALSE(parsed);
   ASSERT_FALSE(parsed) << "Expected validation to fail for a missing diffusion coefficient.";
   EXPECT_TRUE(HasError(parsed.error(), ErrorCode::RequiredKeyNotFound));
+  // The location should point at the gas-phase species reference (line 28), not just anywhere.
+  EXPECT_TRUE(HasErrorAt(parsed.error(), ErrorCode::RequiredKeyNotFound, "28:28"));
 }
 
 TEST(ParseAerosol, RejectsHenrysLawEquilibriumWhenSolventHasNoDensity)
@@ -95,4 +108,48 @@ TEST(ParseAerosol, RejectsHenrysLawEquilibriumWhenSolventHasNoDensity)
   EXPECT_FALSE(parsed);
   ASSERT_FALSE(parsed) << "Expected validation to fail for a missing solvent density.";
   EXPECT_TRUE(HasError(parsed.error(), ErrorCode::RequiredKeyNotFound));
+  // The location should point at the solvent reference (line 31), not just anywhere.
+  EXPECT_TRUE(HasErrorAt(parsed.error(), ErrorCode::RequiredKeyNotFound, "31:18"));
+}
+
+TEST(ParseAerosol, RejectsRepresentationReferencingUnknownPhase)
+{
+  auto parsed = Parse("v1_unit_configs/aerosol/representation_unknown_phase.json");
+  ASSERT_FALSE(parsed) << "Expected validation to fail for a representation referencing an unknown phase.";
+  // Location points at the offending phase name inside the representation's "phases" list (line 14).
+  EXPECT_TRUE(HasErrorAt(parsed.error(), ErrorCode::UnknownPhase, "14:18"));
+}
+
+TEST(ParseAerosol, RejectsDissolvedReactionReferencingUnknownPhase)
+{
+  auto parsed = Parse("v1_unit_configs/aerosol/dissolved_reaction_unknown_phase.json");
+  ASSERT_FALSE(parsed) << "Expected validation to fail for a dissolved reaction referencing an unknown phase.";
+  // Location points at the "condensed phase" value (line 22), reused for reactant/product/solvent checks.
+  EXPECT_TRUE(HasErrorAt(parsed.error(), ErrorCode::UnknownPhase, "22:26"));
+}
+
+TEST(ParseAerosol, RejectsDissolvedReactionReactantNotRegisteredInPhase)
+{
+  auto parsed = Parse("v1_unit_configs/aerosol/dissolved_reaction_reactant_not_in_phase.json");
+  ASSERT_FALSE(parsed) << "Expected validation to fail for a reactant not registered in the reaction's phase.";
+  // Location points at the reactant entry itself (line 25), not the phase or the reaction as a whole.
+  EXPECT_TRUE(HasErrorAt(parsed.error(), ErrorCode::RequestedSpeciesNotRegisteredInPhase, "25:22"));
+}
+
+TEST(ParseAerosol, RejectsHenrysLawEquilibriumReferencingUnknownSolventSpecies)
+{
+  auto parsed = Parse("v1_unit_configs/aerosol/henrys_law_equilibrium_unknown_solvent_species.json");
+  ASSERT_FALSE(parsed) << "Expected validation to fail for a solvent species that isn't declared anywhere.";
+  // Location points at the "solvent" value (line 27). The undeclared species trips both the
+  // phase-membership check (density) and the species-existence check (molecular weight).
+  EXPECT_TRUE(HasErrorAt(parsed.error(), ErrorCode::RequestedSpeciesNotRegisteredInPhase, "27:18"));
+  EXPECT_TRUE(HasErrorAt(parsed.error(), ErrorCode::UnknownSpecies, "27:18"));
+}
+
+TEST(ParseAerosol, RejectsLinearConstraintTermReferencingUnknownPhase)
+{
+  auto parsed = Parse("v1_unit_configs/aerosol/linear_constraint_term_unknown_phase.json");
+  ASSERT_FALSE(parsed) << "Expected validation to fail for a linear constraint term referencing an unknown phase.";
+  // Location points at the term's own "phase" value (line 25), nested inside the terms list.
+  EXPECT_TRUE(HasErrorAt(parsed.error(), ErrorCode::UnknownPhase, "25:29"));
 }

--- a/test/unit/v1/v1_unit_configs/aerosol/dissolved_reaction_reactant_not_in_phase.json
+++ b/test/unit/v1/v1_unit_configs/aerosol/dissolved_reaction_reactant_not_in_phase.json
@@ -1,0 +1,30 @@
+{
+  "version": "1.2.0",
+  "name": "dissolved reaction reactant not registered in phase",
+  "species": [
+    { "name": "A" },
+    { "name": "B" }
+  ],
+  "phases": [
+    { "name": "aqueous", "species": ["A"] }
+  ],
+  "aerosol representations": [
+    {
+      "type": "UNIFORM_SECTION",
+      "name": "cloud",
+      "phases": ["aqueous"],
+      "minimum radius [m]": 1.0e-6,
+      "maximum radius [m]": 1.0e-5
+    }
+  ],
+  "aerosol processes": [
+    {
+      "type": "DISSOLVED_REACTION",
+      "condensed phase": "aqueous",
+      "solvent": "A",
+      "reactants": [ { "name": "B", "coefficient": 1 } ],
+      "products": [ { "name": "A", "coefficient": 1 } ],
+      "rate constant": { "type": "ARRHENIUS", "A": 1.0e3, "C": 100.0 }
+    }
+  ]
+}

--- a/test/unit/v1/v1_unit_configs/aerosol/dissolved_reaction_unknown_phase.json
+++ b/test/unit/v1/v1_unit_configs/aerosol/dissolved_reaction_unknown_phase.json
@@ -1,0 +1,29 @@
+{
+  "version": "1.2.0",
+  "name": "dissolved reaction references unknown phase",
+  "species": [
+    { "name": "A" }
+  ],
+  "phases": [
+    { "name": "aqueous", "species": ["A"] }
+  ],
+  "aerosol representations": [
+    {
+      "type": "UNIFORM_SECTION",
+      "name": "cloud",
+      "phases": ["aqueous"],
+      "minimum radius [m]": 1.0e-6,
+      "maximum radius [m]": 1.0e-5
+    }
+  ],
+  "aerosol processes": [
+    {
+      "type": "DISSOLVED_REACTION",
+      "condensed phase": "not_a_real_phase",
+      "solvent": "A",
+      "reactants": [ { "name": "A", "coefficient": 1 } ],
+      "products": [ { "name": "A", "coefficient": 1 } ],
+      "rate constant": { "type": "ARRHENIUS", "A": 1.0e3, "C": 100.0 }
+    }
+  ]
+}

--- a/test/unit/v1/v1_unit_configs/aerosol/henrys_law_equilibrium_unknown_solvent_species.json
+++ b/test/unit/v1/v1_unit_configs/aerosol/henrys_law_equilibrium_unknown_solvent_species.json
@@ -1,0 +1,31 @@
+{
+  "version": "1.2.0",
+  "name": "henrys law equilibrium references unknown solvent species",
+  "species": [
+    { "name": "A", "molecular weight [kg mol-1]": 0.05 }
+  ],
+  "phases": [
+    { "name": "gas", "species": [ { "name": "A", "diffusion coefficient [m2 s-1]": 1.5e-5 } ] },
+    { "name": "aqueous", "species": ["A"] }
+  ],
+  "aerosol representations": [
+    {
+      "type": "UNIFORM_SECTION",
+      "name": "cloud",
+      "phases": ["aqueous"],
+      "minimum radius [m]": 1.0e-6,
+      "maximum radius [m]": 1.0e-5
+    }
+  ],
+  "aerosol processes": [
+    {
+      "type": "HENRYS_LAW_EQUILIBRIUM",
+      "gas phase": "gas",
+      "gas-phase species": "A",
+      "condensed phase": "aqueous",
+      "condensed-phase species": "A",
+      "solvent": "not_a_real_species",
+      "Henry's law constant": { "HLC_ref [mol m-3 Pa-1]": 1.0e-2, "C [K]": 3000.0 }
+    }
+  ]
+}

--- a/test/unit/v1/v1_unit_configs/aerosol/linear_constraint_term_unknown_phase.json
+++ b/test/unit/v1/v1_unit_configs/aerosol/linear_constraint_term_unknown_phase.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.2.0",
+  "name": "linear constraint term references unknown phase",
+  "species": [
+    { "name": "A" }
+  ],
+  "phases": [
+    { "name": "aqueous", "species": ["A"] }
+  ],
+  "aerosol representations": [
+    {
+      "type": "UNIFORM_SECTION",
+      "name": "cloud",
+      "phases": ["aqueous"],
+      "minimum radius [m]": 1.0e-6,
+      "maximum radius [m]": 1.0e-5
+    }
+  ],
+  "aerosol processes": [
+    {
+      "type": "LINEAR_CONSTRAINT",
+      "algebraic phase": "aqueous",
+      "algebraic species": "A",
+      "diagnose from state": true,
+      "terms": [ { "phase": "not_a_real_phase", "name": "A", "coefficient": 1.0 } ]
+    }
+  ]
+}

--- a/test/unit/v1/v1_unit_configs/aerosol/representation_unknown_phase.json
+++ b/test/unit/v1/v1_unit_configs/aerosol/representation_unknown_phase.json
@@ -1,0 +1,29 @@
+{
+  "version": "1.2.0",
+  "name": "representation references unknown phase",
+  "species": [
+    { "name": "A" }
+  ],
+  "phases": [
+    { "name": "aqueous", "species": ["A"] }
+  ],
+  "aerosol representations": [
+    {
+      "type": "UNIFORM_SECTION",
+      "name": "cloud",
+      "phases": ["not_a_real_phase"],
+      "minimum radius [m]": 1.0e-6,
+      "maximum radius [m]": 1.0e-5
+    }
+  ],
+  "aerosol processes": [
+    {
+      "type": "DISSOLVED_REACTION",
+      "condensed phase": "aqueous",
+      "solvent": "A",
+      "reactants": [ { "name": "A", "coefficient": 1 } ],
+      "products": [ { "name": "A", "coefficient": 1 } ],
+      "rate constant": { "type": "ARRHENIUS", "A": 1.0e3, "C": 100.0 }
+    }
+  ]
+}


### PR DESCRIPTION
This PR:
- Moves definitions within `semantics` namespace from public headers to internal headers. These are internal validation logics, and aren't for user consumption. 
- Adds aerosol validation semantics function through `ValidateAerosolSemantics(const semantics::AerosolInput&)`. Aerosol model needs presence checks for fields such as molecular weight, density and diffusion coefficients. Since aerosol processes has their own unique fields, dedicated semantic structures are needed for validation. 
- Emissions now has its own `ValidateEmissionsModel`. This is based on build input where species, phases, reactions can be empty when building emissions. Currenlty, bundling reactions and emissions under `input` does not represent a data dependency.  They are independent. 
- Renames `ValidateSemantic` to `ValidateReactionsSemantics` because it now checks reactions semantics including species and phases, rather that serving as a general semantic check rule.
- Closes #284