### PR TITLE
Fix remaining v0->v1 conversion gaps (third body, gas phase, surface prefix)

### DIFF
--- a/src/v0/parser.cpp
+++ b/src/v0/parser.cpp
@@ -184,6 +184,27 @@ namespace mechanism_configuration::v0
       }
       mechanism.phases.push_back(gas_phase);
 
+      // Every v0 reaction operates in the single gas phase. Name it explicitly so the
+      // mechanism round-trips to v1, whose parser requires each reaction to declare a
+      // (non-empty) gas phase.
+      auto set_gas_phase = [](auto& reaction_vector)
+      {
+        for (auto& reaction : reaction_vector)
+          reaction.gas_phase = "gas";
+      };
+      set_gas_phase(mechanism.reactions.arrhenius);
+      set_gas_phase(mechanism.reactions.branched);
+      set_gas_phase(mechanism.reactions.emission);
+      set_gas_phase(mechanism.reactions.first_order_loss);
+      set_gas_phase(mechanism.reactions.photolysis);
+      set_gas_phase(mechanism.reactions.surface);
+      set_gas_phase(mechanism.reactions.taylor_series);
+      set_gas_phase(mechanism.reactions.troe);
+      set_gas_phase(mechanism.reactions.ternary_chemical_activation);
+      set_gas_phase(mechanism.reactions.tunneling);
+      set_gas_phase(mechanism.reactions.user_defined);
+      set_gas_phase(mechanism.reactions.lambda_rate_constant);
+
       mechanism.version = Version(0, 0, 0);
     }
 

--- a/src/v0/species_parser.cpp
+++ b/src/v0/species_parser.cpp
@@ -33,7 +33,15 @@ namespace mechanism_configuration::v0
       if (object[keys::ABS_TOLERANCE])
         species.absolute_tolerance = object[keys::ABS_TOLERANCE].as<double>();
       if (object[keys::TRACER_TYPE])
-        species.tracer_type = object[keys::TRACER_TYPE].as<std::string>();
+      {
+        auto tracer_type = object[keys::TRACER_TYPE].as<std::string>();
+        species.tracer_type = tracer_type;
+        // A THIRD_BODY tracer must also be flagged as a third body so the designation
+        // survives serialization to v1 (which represents it via "is third body"); the
+        // v1 "tracer type" string is not otherwise carried through the unified type.
+        if (tracer_type == keys::THIRD_BODY)
+          species.is_third_body = true;
+      }
 
       // Load remaining keys as unknown properties
       for (auto it = object.begin(); it != object.end(); ++it)

--- a/src/v0/surface_parser.cpp
+++ b/src/v0/surface_parser.cpp
@@ -41,8 +41,10 @@ namespace mechanism_configuration::v0
         parameters.reaction_probability = object[keys::PROBABILITY].as<double>();
       }
 
-      std::string name = "SURF." + object[keys::MUSICA_NAME].as<std::string>();
-      parameters.name = name;
+      // Store the bare MUSICA name, like every other v0 reaction parser. The "SURF."
+      // label prefix is added downstream when the reaction is handed to MICM; prefixing
+      // here too produced a doubled "SURF.SURF." label.
+      parameters.name = object[keys::MUSICA_NAME].as<std::string>();
 
       mechanism.reactions.surface.push_back(parameters);
     }

--- a/test/unit/v0/test_arrhenius_config.cpp
+++ b/test/unit/v0/test_arrhenius_config.cpp
@@ -63,6 +63,8 @@ TEST(ArrheniusConfig, ParseConfig)
 
     // first reaction
     {
+      // v0 reactions are all placed in the gas phase so the mechanism round-trips to v1.
+      EXPECT_EQ(mechanism.reactions.arrhenius[0].gas_phase, "gas");
       EXPECT_EQ(mechanism.reactions.arrhenius[0].reactants.size(), 2);
       EXPECT_EQ(mechanism.reactions.arrhenius[0].reactants[0].name, "foo");
       EXPECT_EQ(mechanism.reactions.arrhenius[0].reactants[1].name, "quz");

--- a/test/unit/v0/test_species_config.cpp
+++ b/test/unit/v0/test_species_config.cpp
@@ -29,7 +29,7 @@ TEST(SpeciesConfig, ValidSpeciesConfig)
     Mechanism mechanism = *parsed;
 
     auto& species_vector = mechanism.species;
-    EXPECT_EQ(species_vector.size(), 4);
+    EXPECT_EQ(species_vector.size(), 5);
 
     // first species
     {
@@ -61,6 +61,16 @@ TEST(SpeciesConfig, ValidSpeciesConfig)
       EXPECT_FALSE(species_vector[3].molecular_weight.has_value());
       EXPECT_FALSE(species_vector[3].diffusion_coefficient.has_value());
       EXPECT_FALSE(species_vector[3].absolute_tolerance.has_value());
+      EXPECT_FALSE(species_vector[3].is_third_body.has_value());
+    }
+
+    // fifth species: a THIRD_BODY tracer must set is_third_body so the designation
+    // survives serialization to v1 (which represents third bodies via "is third body").
+    {
+      EXPECT_EQ(species_vector[4].name, "M");
+      EXPECT_EQ(species_vector[4].tracer_type, "THIRD_BODY");
+      ASSERT_TRUE(species_vector[4].is_third_body.has_value());
+      EXPECT_TRUE(species_vector[4].is_third_body.value());
     }
 
     // In v0 all species are placed in the gas phase. The species-level diffusion
@@ -69,7 +79,7 @@ TEST(SpeciesConfig, ValidSpeciesConfig)
     ASSERT_EQ(mechanism.phases.size(), 1);
     auto& gas_phase = mechanism.phases[0];
     EXPECT_EQ(gas_phase.name, "gas");
-    ASSERT_EQ(gas_phase.species.size(), 4);
+    ASSERT_EQ(gas_phase.species.size(), 5);
 
     EXPECT_EQ(gas_phase.species[0].name, "foo");
     EXPECT_EQ(gas_phase.species[0].diffusion_coefficient, 2.3e-4);
@@ -82,5 +92,8 @@ TEST(SpeciesConfig, ValidSpeciesConfig)
 
     EXPECT_EQ(gas_phase.species[3].name, "quz");
     EXPECT_FALSE(gas_phase.species[3].diffusion_coefficient.has_value());
+
+    EXPECT_EQ(gas_phase.species[4].name, "M");
+    EXPECT_FALSE(gas_phase.species[4].diffusion_coefficient.has_value());
   }
 }

--- a/test/unit/v0/test_surface_config.cpp
+++ b/test/unit/v0/test_surface_config.cpp
@@ -71,7 +71,7 @@ TEST(SurfaceConfig, ParseConfig)
       EXPECT_EQ(process_vector[0].gas_phase_products[0].coefficient, 1.0);
       EXPECT_EQ(process_vector[0].gas_phase_products[1].name, "baz");
       EXPECT_EQ(process_vector[0].gas_phase_products[1].coefficient, 3.2);
-      EXPECT_EQ(process_vector[0].name, "SURF.kfoo");
+      EXPECT_EQ(process_vector[0].name, "kfoo");
       EXPECT_EQ(process_vector[0].reaction_probability, 1.0);
       auto it = std::find_if(
           mechanism.species.begin(),
@@ -89,7 +89,7 @@ TEST(SurfaceConfig, ParseConfig)
       EXPECT_EQ(process_vector[1].gas_phase_products[0].coefficient, 0.5);
       EXPECT_EQ(process_vector[1].gas_phase_products[1].name, "foo");
       EXPECT_EQ(process_vector[1].gas_phase_products[1].coefficient, 1.0);
-      EXPECT_EQ(process_vector[1].name, "SURF.kbar");
+      EXPECT_EQ(process_vector[1].name, "kbar");
       EXPECT_EQ(process_vector[1].reaction_probability, 0.5);
       auto it = std::find_if(
           mechanism.species.begin(),

--- a/test/unit/v0/v0_unit_configs/species/valid/species.json
+++ b/test/unit/v0/v0_unit_configs/species/valid/species.json
@@ -20,6 +20,11 @@
     {
       "name": "quz",
       "type": "CHEM_SPEC"
+    },
+    {
+      "name": "M",
+      "type": "CHEM_SPEC",
+      "tracer type": "THIRD_BODY"
     }
   ]
 }

--- a/test/unit/v0/v0_unit_configs/species/valid/species.yaml
+++ b/test/unit/v0/v0_unit_configs/species/valid/species.yaml
@@ -12,3 +12,6 @@ camp-data:
   absolute tolerance: 1.0e-10
 - name: quz
   type: CHEM_SPEC
+- name: M
+  type: CHEM_SPEC
+  tracer type: THIRD_BODY


### PR DESCRIPTION
Follow-up to #309. That PR fixed the diffusion coefficient, but three more v0-parser issues block converting a real v0 (CAMP) config to a loadable v1 mechanism. (#309 was squash-merged with only its first commit, so the third-body and gas-phase fixes below — briefly part of that PR — are not actually in `main`; they are re-included here.)

## Fixes

1. **THIRD_BODY tracer dropped.** A `CHEM_SPEC` with `tracer type: THIRD_BODY` recorded only the tracer-type string, which the unified type does not carry into v1 serialization (v1 uses `is third body`). Set `is_third_body` so the designation survives conversion — otherwise species like `M` silently lose their third-body role.

2. **Empty reaction gas phase.** v0 reactions left `gas_phase` empty, but the v1 parser requires every reaction to name a non-empty gas phase, so a converted mechanism failed to re-parse with `Unknown phase ''`. Place all v0 reactions in the `gas` phase, mirroring how all v0 species are placed there.

3. **Doubled `SURF.` prefix.** The v0 surface parser stored the name as `"SURF." + MUSICA name` — the only v0 reaction parser that prefixes the name (photolysis, emission, loss, user-defined all store the bare name and let the MICM conversion add the label prefix). Since that conversion also prepends `SURF.`, surface labels became `SURF.SURF.<name>`, breaking consumers that build per-reaction columns from the name (e.g. music_box's `SURF.<name>.<property>.<unit>`). Store the bare name so the single downstream prefix yields `SURF.<name>`.

## Tests

Extends the v0 species, arrhenius, and surface unit tests. All 12 v0 tests pass.

Together with NCAR/musica#983 (stamp v1 version on `--convert`), this lets `musica-cli --convert` produce a v1 mechanism that loads directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)