### PR TITLE
Keep reactant-less v0 photolysis as an emission

### DIFF
--- a/src/v0/photolysis_parser.cpp
+++ b/src/v0/photolysis_parser.cpp
@@ -31,10 +31,19 @@ namespace mechanism_configuration::v0
       errors.insert(errors.end(), parse_error.begin(), parse_error.end());
 
       double scaling_factor = object[keys::SCALING_FACTOR] ? object[keys::SCALING_FACTOR].as<double>() : 1.0;
+      std::string name = object[keys::MUSICA_NAME].as<std::string>();
 
-      if (!reactants.empty())
+      if (reactants.empty())
       {
-        std::string name = object[keys::MUSICA_NAME].as<std::string>();
+        // A photolysis reaction with no reactants is a pure production term --
+        // Music Box Interactive encodes emissions this way (as a photolysis so
+        // they can carry an irr product). Represent it as an emission, which has
+        // no reactant, so it is not silently dropped.
+        types::Emission emission = { .scaling_factor = scaling_factor, .products = products, .name = name };
+        mechanism.reactions.emission.push_back(emission);
+      }
+      else
+      {
         types::Photolysis user_defined = {
           .scaling_factor = scaling_factor, .reactants = reactants[0], .products = products, .name = name
         };

--- a/test/unit/v0/test_photolysis_config.cpp
+++ b/test/unit/v0/test_photolysis_config.cpp
@@ -86,6 +86,15 @@ TEST(PhotolysisConfig, ParseConfig)
       EXPECT_EQ(process_vector[1].name, "jbar");
       EXPECT_EQ(process_vector[1].scaling_factor, 2.5);
     }
+
+    // A photolysis reaction with no reactants (an emission encoded as photolysis)
+    // is kept as an emission rather than dropped.
+    auto& emissions = mechanism.reactions.emission;
+    ASSERT_EQ(emissions.size(), 1);
+    EXPECT_EQ(emissions[0].name, "jemis");
+    ASSERT_EQ(emissions[0].products.size(), 1);
+    EXPECT_EQ(emissions[0].products[0].name, "foo");
+    EXPECT_EQ(emissions[0].products[0].coefficient, 1.0);
   }
 }
 

--- a/test/unit/v0/v0_unit_configs/photolysis/valid/reactions.json
+++ b/test/unit/v0/v0_unit_configs/photolysis/valid/reactions.json
@@ -26,6 +26,14 @@
           },
           "MUSICA name": "jbar",
           "scaling factor": 2.5
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "reactants": { },
+          "products": {
+            "foo": { "yield": 1.0 }
+          },
+          "MUSICA name": "jemis"
         }
       ]
     }

--- a/test/unit/v0/v0_unit_configs/photolysis/valid/reactions.yaml
+++ b/test/unit/v0/v0_unit_configs/photolysis/valid/reactions.yaml
@@ -19,4 +19,10 @@ camp-data:
       bar: {}
     scaling factor: 2.5
     type: PHOTOLYSIS
+  - MUSICA name: jemis
+    products:
+      foo:
+        yield: 1.0
+    reactants: {}
+    type: PHOTOLYSIS
   type: MECHANISM


### PR DESCRIPTION
## Problem

The v0 photolysis parser silently drops `PHOTOLYSIS` reactions whose `reactants` is empty (`{}`). Music Box Interactive encodes **emissions** as reactant-less photolysis so they can carry an `irr__` product, e.g.:

```json
{ "type": "PHOTOLYSIS", "__music_box_type": "EMISSION", "MUSICA name": "EMIS_NO",
  "reactants": {}, "products": {"NO": {"yield": 1}, "irr__...": {"yield": 1}} }
```

In the CB05 MBI config, 14 of 39 photolysis reactions are reactant-less; `parse()` returned only the 25 with reactants, so those emissions (and their irr accumulators) vanished. Downstream this breaks a music_box run: the conditions CSV still supplies their rates → `User-defined rate parameter PHOTO.EMIS_NO not found in the mechanism`.

## Fix

A reactant-less photolysis is a pure production term, so parse it into the `Emission` list (which has no reactant) instead of dropping it. This keeps the reaction and its `irr__` product. Reactions with a reactant are unchanged. Adds a v0 photolysis test case (a reactant-less reaction is now asserted to appear as an emission). All 12 v0 tests pass.

Addresses NCAR/musica#986.

## Follow-ups for the full pipeline

These reactions become **emissions**, so their MICM rate-parameter label changes from `PHOTO.<name>` to `EMIS.<name>`. To run a converted MBI config (e.g. CB05) end-to-end, two more pieces are needed:
1. a musica release picking up this mechanism_configuration change;
2. the music_box config converter remapping the `PHOTO.<name>` rate-parameter CSV columns to `EMIS.<name>` for reactions that are emissions.

(An alternative design — making `Photolysis.reactants` a vector to allow zero reactants while keeping the `PHOTO.` label — was rejected here because it changes the `Photolysis` type and would break musica's bindings, requiring an atomic cross-repo release. Routing to `Emission` is self-contained.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)