### PR TITLE
Allow photolysis reactions with no reactants

### DIFF
--- a/include/mechanism_configuration/types/reactions.hpp
+++ b/include/mechanism_configuration/types/reactions.hpp
@@ -102,8 +102,8 @@ namespace mechanism_configuration::types
   {
     /// @brief Scaling factor to apply to user-provided rate constants
     double scaling_factor{ 1.0 };
-    /// @brief A single reactant
-    ReactionComponent reactants;
+    /// @brief Reactants (at most one; empty for a pure production term, e.g. an emission)
+    std::vector<ReactionComponent> reactants;
     /// @brief A list of products
     std::vector<ReactionComponent> products;
     /// @brief An identifier, optional, uniqueness not enforced

--- a/src/v0/photolysis_parser.cpp
+++ b/src/v0/photolysis_parser.cpp
@@ -31,15 +31,15 @@ namespace mechanism_configuration::v0
       errors.insert(errors.end(), parse_error.begin(), parse_error.end());
 
       double scaling_factor = object[keys::SCALING_FACTOR] ? object[keys::SCALING_FACTOR].as<double>() : 1.0;
+      std::string name = object[keys::MUSICA_NAME].as<std::string>();
 
-      if (!reactants.empty())
-      {
-        std::string name = object[keys::MUSICA_NAME].as<std::string>();
-        types::Photolysis user_defined = {
-          .scaling_factor = scaling_factor, .reactants = reactants[0], .products = products, .name = name
-        };
-        mechanism.reactions.photolysis.push_back(user_defined);
-      }
+      // Reactants may be empty: Music Box Interactive encodes emissions as a
+      // reactant-less photolysis (so they can carry an irr product). Keep the
+      // reaction rather than dropping it.
+      types::Photolysis user_defined = {
+        .scaling_factor = scaling_factor, .reactants = reactants, .products = products, .name = name
+      };
+      mechanism.reactions.photolysis.push_back(user_defined);
     }
 
     return errors;

--- a/src/v1/reactions/photolysis.cpp
+++ b/src/v1/reactions/photolysis.cpp
@@ -92,7 +92,7 @@ namespace mechanism_configuration::v1
     types::Photolysis photolysis;
 
     photolysis.gas_phase = object[keys::gas_phase].as<std::string>();
-    photolysis.reactants = ParseReactionComponent(object, keys::reactants);
+    photolysis.reactants = ParseReactionComponents(object, keys::reactants);
     photolysis.products = ParseReactionComponents(object, keys::products);
     photolysis.unknown_properties = GetComments(object);
 

--- a/src/validate.cpp
+++ b/src/validate.cpp
@@ -428,7 +428,7 @@ namespace mechanism_configuration
     for (const auto& x : r.first_order_loss)
       add("FIRST_ORDER_LOSS", x.gas_phase, Refs({ x.reactants }), Refs(x.products));
     for (const auto& x : r.photolysis)
-      add("PHOTOLYSIS", x.gas_phase, Refs({ x.reactants }), Refs(x.products));
+      add("PHOTOLYSIS", x.gas_phase, Refs(x.reactants), Refs(x.products));
     for (const auto& x : r.surface)
       add("SURFACE", x.gas_phase, Refs({ x.gas_phase_species }), Refs(x.gas_phase_products));
     for (const auto& x : r.branched)

--- a/test/unit/v0/test_photolysis_config.cpp
+++ b/test/unit/v0/test_photolysis_config.cpp
@@ -61,11 +61,11 @@ TEST(PhotolysisConfig, ParseConfig)
     Mechanism mechanism = *parsed;
 
     auto& process_vector = mechanism.reactions.photolysis;
-    EXPECT_EQ(process_vector.size(), 2);
+    EXPECT_EQ(process_vector.size(), 3);
 
     // first reaction
     {
-      EXPECT_EQ(process_vector[0].reactants.name, "foo");
+      EXPECT_EQ(process_vector[0].reactants[0].name, "foo");
       EXPECT_EQ(process_vector[0].products.size(), 2);
       EXPECT_EQ(process_vector[0].products[0].name, "bar");
       EXPECT_EQ(process_vector[0].products[0].coefficient, 1.0);
@@ -77,7 +77,7 @@ TEST(PhotolysisConfig, ParseConfig)
 
     // second reaction
     {
-      EXPECT_EQ(process_vector[1].reactants.name, "bar");
+      EXPECT_EQ(process_vector[1].reactants[0].name, "bar");
       EXPECT_EQ(process_vector[1].products.size(), 2);
       EXPECT_EQ(process_vector[1].products[0].name, "bar");
       EXPECT_EQ(process_vector[1].products[0].coefficient, 0.5);
@@ -85,6 +85,16 @@ TEST(PhotolysisConfig, ParseConfig)
       EXPECT_EQ(process_vector[1].products[1].coefficient, 1.0);
       EXPECT_EQ(process_vector[1].name, "jbar");
       EXPECT_EQ(process_vector[1].scaling_factor, 2.5);
+    }
+
+    // A photolysis reaction with no reactants (an emission encoded as photolysis)
+    // is kept, with an empty reactants list, rather than dropped.
+    {
+      EXPECT_EQ(process_vector[2].reactants.size(), 0);
+      ASSERT_EQ(process_vector[2].products.size(), 1);
+      EXPECT_EQ(process_vector[2].products[0].name, "foo");
+      EXPECT_EQ(process_vector[2].products[0].coefficient, 1.0);
+      EXPECT_EQ(process_vector[2].name, "jemis");
     }
   }
 }

--- a/test/unit/v0/v0_unit_configs/photolysis/valid/reactions.json
+++ b/test/unit/v0/v0_unit_configs/photolysis/valid/reactions.json
@@ -26,6 +26,14 @@
           },
           "MUSICA name": "jbar",
           "scaling factor": 2.5
+        },
+        {
+          "type": "PHOTOLYSIS",
+          "reactants": { },
+          "products": {
+            "foo": { "yield": 1.0 }
+          },
+          "MUSICA name": "jemis"
         }
       ]
     }

--- a/test/unit/v0/v0_unit_configs/photolysis/valid/reactions.yaml
+++ b/test/unit/v0/v0_unit_configs/photolysis/valid/reactions.yaml
@@ -19,4 +19,10 @@ camp-data:
       bar: {}
     scaling factor: 2.5
     type: PHOTOLYSIS
+  - MUSICA name: jemis
+    products:
+      foo:
+        yield: 1.0
+    reactants: {}
+    type: PHOTOLYSIS
   type: MECHANISM

--- a/test/unit/v1/reactions/test_parse_photolysis.cpp
+++ b/test/unit/v1/reactions/test_parse_photolysis.cpp
@@ -24,8 +24,8 @@ TEST(ParserBase, CanParseValidPhotolysisReaction)
     EXPECT_EQ(mechanism.reactions.photolysis[0].gas_phase, "gas");
     EXPECT_EQ(mechanism.reactions.photolysis[0].name, "my photolysis");
     EXPECT_EQ(mechanism.reactions.photolysis[0].scaling_factor, 12.3);
-    EXPECT_EQ(mechanism.reactions.photolysis[0].reactants.name, "B");
-    EXPECT_EQ(mechanism.reactions.photolysis[0].reactants.coefficient, 1);
+    EXPECT_EQ(mechanism.reactions.photolysis[0].reactants[0].name, "B");
+    EXPECT_EQ(mechanism.reactions.photolysis[0].reactants[0].coefficient, 1);
     EXPECT_EQ(mechanism.reactions.photolysis[0].products.size(), 1);
     EXPECT_EQ(mechanism.reactions.photolysis[0].products[0].name, "C");
     EXPECT_EQ(mechanism.reactions.photolysis[0].products[0].coefficient, 1);
@@ -34,8 +34,8 @@ TEST(ParserBase, CanParseValidPhotolysisReaction)
 
     EXPECT_EQ(mechanism.reactions.photolysis[1].gas_phase, "gas");
     EXPECT_EQ(mechanism.reactions.photolysis[1].scaling_factor, 1);
-    EXPECT_EQ(mechanism.reactions.photolysis[1].reactants.name, "B");
-    EXPECT_EQ(mechanism.reactions.photolysis[1].reactants.coefficient, 1.2);
+    EXPECT_EQ(mechanism.reactions.photolysis[1].reactants[0].name, "B");
+    EXPECT_EQ(mechanism.reactions.photolysis[1].reactants[0].coefficient, 1.2);
     EXPECT_EQ(mechanism.reactions.photolysis[1].products.size(), 1);
     EXPECT_EQ(mechanism.reactions.photolysis[1].products[0].name, "C");
     EXPECT_EQ(mechanism.reactions.photolysis[1].products[0].coefficient, 0.2);


### PR DESCRIPTION
## Problem

The v0 photolysis parser silently drops `PHOTOLYSIS` reactions whose `reactants` is empty. Music Box Interactive encodes emissions as reactant-less photolysis so they can carry an `irr__` product; in the CB05 config, 14 of 39 photolysis reactions are reactant-less, so they (and their irr accumulators) vanished. A converted config then fails to run: the conditions CSV supplies rates for the dropped reactions (`PHOTO.EMIS_NO not found`).

## Fix

Make `Photolysis::reactants` a vector holding at most one component, and keep reactant-less reactions instead of dropping them. The reaction **stays a PHOTOLYSIS** (keeping its `PHOTO.<name>` rate-parameter label), so downstream conditions that reference it by that label keep working with no remapping.

- `types::Photolysis::reactants`: `ReactionComponent` → `std::vector<ReactionComponent>`
- v0 parser keeps the reaction with its (possibly empty) reactants
- v1 parser parses reactants as a list; the schema already allowed 0-or-1 (it only errors on >1), and an empty list validates
- `validate.cpp` and the v0/v1 photolysis tests updated (a reactant-less v0 reaction is asserted to stay a photolysis with an empty reactants list)

All 34 tests pass.

Addresses NCAR/musica#986. **Pairs with a musica change** to handle the now list-valued photolysis reactants in the Python layer (getter/setter/serialize), plus a mechanism_configuration tag bump; they must be released together.

Supersedes #311 (which routed these to `Emission`; keeping them as photolysis avoids changing the rate-parameter label, so no converter remap is needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)